### PR TITLE
Incorrect Handling of Token Decimals in addToken

### DIFF
--- a/src/interfaces/ITokenRegistry.sol
+++ b/src/interfaces/ITokenRegistry.sol
@@ -65,7 +65,7 @@ interface ITokenRegistry {
     /// @param token The address of the token to add
     /// @param decimals The number of decimals for the token
     /// @param initialPrice The initial price for the token
-    function addToken(IERC20 token, uint256 decimals, uint256 initialPrice) external;
+    function addToken(IERC20 token, uint8 decimals, uint256 initialPrice) external;
 
     /// @notice Removes a token from the registry
     /// @param token The address of the token to remove

--- a/src/utils/TokenRegistry.sol
+++ b/src/utils/TokenRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {AccessControlUpgradeable} from "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
 import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -58,12 +59,17 @@ contract TokenRegistry is
     /// @param initialPrice Initial price for the token
     function addToken(
         IERC20 token,
-        uint256 decimals,
+        uint8 decimals,
         uint256 initialPrice
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (tokens[token].decimals != 0) revert TokenAlreadySupported(token);
-        if (decimals == 0) revert InvalidDecimals();
         if (initialPrice == 0) revert InvalidPrice();
+        if (decimals == 0) revert InvalidDecimals();
+
+        try IERC20Metadata(address(token)).decimals() returns (uint8 decimalsFromContract) {
+            if (decimalsFromContract == 0) revert InvalidDecimals();
+            if (decimals != decimalsFromContract) revert InvalidDecimals();
+        } catch {} // Fallback to `decimals` if token contract doesn't implement `decimals()`
 
         tokens[token] = TokenInfo({
             decimals: decimals,

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract MockERC20 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
@@ -10,3 +11,31 @@ contract MockERC20 is ERC20 {
         _mint(to, amount);
     }
 }
+
+contract MockERC20NoDecimals is IERC20 {
+     // No decimals function
+
+     function totalSupply() external pure returns (uint256) {
+         return 0;
+     }
+
+     function balanceOf(address) external pure returns (uint256) {
+         return 0;
+     }
+
+     function transfer(address, uint256) external pure returns (bool) {
+         return true;
+     }
+
+     function allowance(address, address) external pure returns (uint256) {
+         return 0;
+     }
+
+     function approve(address, uint256) external pure returns (bool) {
+         return true;
+     }
+
+     function transferFrom(address, address, uint256) external pure returns (bool) {
+         return true;
+     }
+ }


### PR DESCRIPTION
### Description
The addToken function in the TokenRegistry contract fails to validate that the specified decimals parameter matches the actual decimals of the ERC20 token as defined by the IERC20 interface. This oversight allows for a mismatch between the registry's tracked decimals and the token's actual decimals.

### Remediation
The addToken function now makes sure the decimals param is equivalent to the output of ERC20.decimals().