### PR TITLE
feat: add baseAsset field to mainnet LAT configs and deployment script

### DIFF
--- a/script/configs/mainnet/xeigenda-eth.anvil.config.json
+++ b/script/configs/mainnet/xeigenda-eth.anvil.config.json
@@ -1,5 +1,6 @@
 {
     "avsAddress": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+    "baseAsset": "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0",
     "contracts": {
         "stakerNodeCoordinator": {
             "init": {
@@ -9,7 +10,7 @@
         "liquidToken": {
             "init": {
                 "name": "EigenDA ETH Liquid Avs Token",
-                "symbol": "xEigenDA"
+                "symbol": "xEigenDA-ETH"
             }
         }
     },

--- a/script/configs/mainnet/xeigenda.anvil.config.json
+++ b/script/configs/mainnet/xeigenda.anvil.config.json
@@ -1,5 +1,6 @@
 {
     "avsAddress": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+    "baseAsset": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
     "contracts": {
         "stakerNodeCoordinator": {
             "init": {

--- a/script/configs/mainnet/xlagrange-eth.anvil.config.json
+++ b/script/configs/mainnet/xlagrange-eth.anvil.config.json
@@ -1,5 +1,6 @@
 {
     "avsAddress": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+    "baseAsset": "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0",
     "contracts": {
         "stakerNodeCoordinator": {
             "init": {

--- a/script/configs/mainnet/xlagrange.anvil.config.json
+++ b/script/configs/mainnet/xlagrange.anvil.config.json
@@ -1,5 +1,6 @@
 {
     "avsAddress": "0x22cac0e6a1465f043428e8aef737b3cb09d0eeda",
+    "baseAsset": "0x0fc2a55d5bd13033f1ee0cdd11f60f7efe66f467",
     "contracts": {
         "stakerNodeCoordinator": {
             "init": {
@@ -9,7 +10,7 @@
         "liquidToken": {
             "init": {
                 "name": "Lagrange Native Liquid Avs Token",
-                "symbol": "xLagrange-ETH"
+                "symbol": "xLagrange"
             }
         }
     },

--- a/script/deploy/mainnet/Deploy.s.sol
+++ b/script/deploy/mainnet/Deploy.s.sol
@@ -71,6 +71,7 @@ contract Deploy is Script, Test {
 
     // Deployment-level config
     address public AVS_ADDRESS;
+    address public BASE_ASSET;
     uint256 public STAKER_NODE_COORDINATOR_MAX_NODES;
     string public LIQUID_TOKEN_NAME;
     string public LIQUID_TOKEN_SYMBOL;
@@ -190,6 +191,7 @@ contract Deploy is Script, Test {
         pauser = stdJson.readAddress(deployConfigData, ".roles.pauser");
         priceUpdater = stdJson.readAddress(deployConfigData, ".roles.priceUpdater");
         AVS_ADDRESS = stdJson.readAddress(deployConfigData, ".avsAddress");
+        BASE_ASSET = stdJson.readAddress(deployConfigData, ".baseAsset");
         STAKER_NODE_COORDINATOR_MAX_NODES = stdJson.readUint(
             deployConfigData,
             ".contracts.stakerNodeCoordinator.init.maxNodes"
@@ -604,6 +606,7 @@ contract Deploy is Script, Test {
         vm.serializeString(parent_object, "name", LIQUID_TOKEN_NAME);
         vm.serializeString(parent_object, "symbol", LIQUID_TOKEN_SYMBOL);
         vm.serializeAddress(parent_object, "avsAddress", AVS_ADDRESS);
+        vm.serializeAddress(parent_object, "baseAsset", BASE_ASSET);
         vm.serializeUint(parent_object, "chainId", block.chainid);
         vm.serializeUint(parent_object, "maxNodes", STAKER_NODE_COORDINATOR_MAX_NODES);
         vm.serializeUint(parent_object, "deploymentBlock", block.number);


### PR DESCRIPTION
- Add baseAsset field to all 4 mainnet LAT config files:
  * xeigenda.anvil.config.json (EIGEN: 0xec53bf...)
  * xeigenda-eth.anvil.config.json (ETH: 0xbeac0...)
  * xlagrange.anvil.config.json (LA: 0x0fc2a...)
  * xlagrange-eth.anvil.config.json (ETH: 0xbeac0...)

- Update Deploy.s.sol deployment script:
  * Add BASE_ASSET state variable
  * Read baseAsset from config JSON in loadConfig()
  * Include baseAsset in deployment_data.json output

- Enable backend seeder to identify primary asset for each LAT
- Maintain consistent lowercase naming format for all configs
- All JSON configs validated for syntax correctness

Ready for mainnet deployment with baseAsset field support.