### PR TITLE
Feat: Withdrawal Manager

### DIFF
--- a/script/deploy/holesky/Deploy.s.sol
+++ b/script/deploy/holesky/Deploy.s.sol
@@ -23,6 +23,8 @@ import {ILiquidTokenManager} from "../../../src/interfaces/ILiquidTokenManager.s
 import {StakerNode} from "../../../src/core/StakerNode.sol";
 import {StakerNodeCoordinator} from "../../../src/core/StakerNodeCoordinator.sol";
 import {IStakerNodeCoordinator} from "../../../src/interfaces/IStakerNodeCoordinator.sol";
+import {WithdrawalManager} from "../../../src/core/WithdrawalManager.sol";
+import {IWithdrawalManager} from "../../../src/interfaces/IWithdrawalManager.sol";
 
 /// @dev To load env file:
 // source .env
@@ -88,6 +90,7 @@ contract Deploy is Script, Test {
     TokenRegistryOracle tokenRegistryOracleImpl;
     LiquidTokenManager liquidTokenManagerImpl;
     StakerNodeCoordinator stakerNodeCoordinatorImpl;
+    WithdrawalManager withdrawalManagerImpl;
     StakerNode stakerNodeImpl;
 
     // Proxy contracts
@@ -95,6 +98,7 @@ contract Deploy is Script, Test {
     TokenRegistryOracle tokenRegistryOracle;
     LiquidTokenManager liquidTokenManager;
     StakerNodeCoordinator stakerNodeCoordinator;
+    WithdrawalManager withdrawalManager;
 
     // Deployment blocks and timestamps
     uint256 public proxyAdminDeployBlock;
@@ -108,6 +112,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerImplDeployTimestamp;
     uint256 public stakerNodeCoordinatorImplDeployBlock;
     uint256 public stakerNodeCoordinatorImplDeployTimestamp;
+    uint256 public withdrawalManagerImplDeployBlock;
+    uint256 public withdrawalManagerImplDeployTimestamp;
     uint256 public stakerNodeImplDeployBlock;
     uint256 public stakerNodeImplDeployTimestamp;
 
@@ -119,6 +125,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerProxyDeployTimestamp;
     uint256 public stakerNodeCoordinatorProxyDeployBlock;
     uint256 public stakerNodeCoordinatorProxyDeployTimestamp;
+    uint256 public withdrawalManagerProxyDeployBlock;
+    uint256 public withdrawalManagerProxyDeployTimestamp;
 
     // Initialization timestamps and blocks
     uint256 public tokenRegistryOracleInitBlock;
@@ -129,6 +137,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerInitTimestamp;
     uint256 public stakerNodeCoordinatorInitBlock;
     uint256 public stakerNodeCoordinatorInitTimestamp;
+    uint256 public withdrawalManagerInitBlock;
+    uint256 public withdrawalManagerInitTimestamp;
     uint256 public oracleSalt;
 
     function run(string memory deployConfigFileName) external {
@@ -155,7 +165,7 @@ contract Deploy is Script, Test {
     }
 
     // Helper function to count array entries
-    function _countTokens(string memory deployConfigData) internal returns (uint256) {
+    function _countTokens(string memory deployConfigData) internal view returns (uint256) {
         uint256 i = 0;
         while (true) {
             string memory prefix = string.concat(".tokens[", vm.toString(i), "].addresses.token");
@@ -261,6 +271,10 @@ contract Deploy is Script, Test {
         stakerNodeCoordinatorImplDeployTimestamp = block.timestamp;
         stakerNodeCoordinatorImpl = new StakerNodeCoordinator();
 
+        withdrawalManagerImplDeployBlock = block.number;
+        withdrawalManagerImplDeployTimestamp = block.timestamp;
+        withdrawalManagerImpl = new WithdrawalManager();
+
         stakerNodeImplDeployBlock = block.number;
         stakerNodeImplDeployTimestamp = block.timestamp;
         stakerNodeImpl = new StakerNode();
@@ -290,6 +304,12 @@ contract Deploy is Script, Test {
         liquidToken = LiquidToken(
             address(new TransparentUpgradeableProxy(address(liquidTokenImpl), address(proxyAdmin), ""))
         );
+
+        withdrawalManagerProxyDeployBlock = block.number;
+        withdrawalManagerProxyDeployTimestamp = block.timestamp;
+        withdrawalManager = WithdrawalManager(
+            address(new TransparentUpgradeableProxy(address(withdrawalManagerImpl), address(proxyAdmin), ""))
+        );
     }
 
     function initializeProxies() internal {
@@ -297,6 +317,7 @@ contract Deploy is Script, Test {
         _initializeLiquidTokenManager();
         _initializeStakerNodeCoordinator();
         _initializeLiquidToken();
+        _initializeWithdrawalManager();
     }
 
     function _initializeTokenRegistryOracle() internal {
@@ -325,6 +346,7 @@ contract Deploy is Script, Test {
                 delegationManager: IDelegationManager(delegationManager),
                 stakerNodeCoordinator: stakerNodeCoordinator,
                 tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle)),
+                withdrawalManager: withdrawalManager,
                 initialOwner: msg.sender, // burner, will transfer to admin
                 strategyController: admin,
                 priceUpdater: address(tokenRegistryOracle)
@@ -338,6 +360,7 @@ contract Deploy is Script, Test {
         stakerNodeCoordinator.initialize(
             IStakerNodeCoordinator.Init({
                 liquidTokenManager: liquidTokenManager,
+                withdrawalManager: withdrawalManager,
                 strategyManager: IStrategyManager(strategyManager),
                 delegationManager: IDelegationManager(delegationManager),
                 maxNodes: STAKER_NODE_COORDINATOR_MAX_NODES,
@@ -360,7 +383,22 @@ contract Deploy is Script, Test {
                 initialOwner: admin,
                 pauser: pauser,
                 liquidTokenManager: ILiquidTokenManager(address(liquidTokenManager)),
-                tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle))
+                tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle)),
+                withdrawalManager: withdrawalManager
+            })
+        );
+    }
+
+    function _initializeWithdrawalManager() internal {
+        withdrawalManagerInitBlock = block.number;
+        withdrawalManagerInitTimestamp = block.timestamp;
+        withdrawalManager.initialize(
+            IWithdrawalManager.Init({
+                initialOwner: admin,
+                delegationManager: IDelegationManager(delegationManager),
+                liquidToken: liquidToken,
+                liquidTokenManager: liquidTokenManager,
+                stakerNodeCoordinator: stakerNodeCoordinator
             })
         );
     }
@@ -454,6 +492,12 @@ contract Deploy is Script, Test {
             _getImplementationFromProxy(address(tokenRegistryOracle)) == address(tokenRegistryOracleImpl),
             "TokenRegistryOracle proxy implementation mismatch"
         );
+
+        // WithdrawalManager
+        require(
+            _getImplementationFromProxy(address(withdrawalManager)) == address(withdrawalManagerImpl),
+            "WithdrawalManager proxy implementation mismatch"
+        );
     }
 
     function _verifyContractConnections() internal view {
@@ -503,6 +547,24 @@ contract Deploy is Script, Test {
         require(
             address(tokenRegistryOracle.liquidTokenManager()) == address(liquidTokenManager),
             "TokenRegistryOracle: wrong liquidTokenManager"
+        );
+
+        // WithdrawalManager
+        require(
+            address(withdrawalManager.delegationManager()) == address(delegationManager),
+            "WithdrawalManager: wrong delegationManager"
+        );
+        require(
+            address(withdrawalManager.liquidToken()) == address(liquidToken),
+            "WithdrawalManager: wrong liquidToken"
+        );
+        require(
+            address(withdrawalManager.liquidTokenManager()) == address(liquidTokenManager),
+            "WithdrawalManager: wrong liquidTokenManager"
+        );
+        require(
+            address(withdrawalManager.stakerNodeCoordinator()) == address(stakerNodeCoordinator),
+            "WithdrawalManager: wrong stakerNodeCoordinator"
         );
 
         // Assets and strategies
@@ -588,11 +650,13 @@ contract Deploy is Script, Test {
             tokenRegistryOracle.hasRole(tokenRegistryOracle.RATE_UPDATER_ROLE(), priceUpdater),
             "Rate Updater role not assigned to priceUpdater in TokenRegistryOracle"
         );
-
         require(
             tokenRegistryOracle.hasRole(tokenRegistryOracle.RATE_UPDATER_ROLE(), address(liquidToken)),
             "Rate Updater role not assigned to LiquidToken in TokenRegistryOracle"
         );
+
+        // WithdrawalManager
+        require(withdrawalManager.hasRole(adminRole, admin), "Admin role not assigned in WithdrawalManager");
     }
 
     function writeDeploymentOutput() internal {
@@ -655,9 +719,20 @@ contract Deploy is Script, Test {
             tokenRegistryOracleImplDeployTimestamp * 1000
         );
 
+        // WithdrawalManager implementation
+        string memory withdrawalManagerImpl_obj = "withdrawalManager";
+        vm.serializeAddress(withdrawalManagerImpl_obj, "address", address(withdrawalManagerImpl));
+        vm.serializeUint(withdrawalManagerImpl_obj, "block", withdrawalManagerImplDeployBlock);
+        string memory withdrawalManagerImpl_output = vm.serializeUint(
+            withdrawalManagerImpl_obj,
+            "timestamp",
+            withdrawalManagerImplDeployTimestamp * 1000
+        );
+
         // Combine all implementation objects
         vm.serializeString(implementation, "liquidTokenManager", liquidTokenManagerImpl_output);
         vm.serializeString(implementation, "stakerNodeCoordinator", stakerNodeCoordinatorImpl_output);
+        vm.serializeString(implementation, "withdrawalManager", withdrawalManagerImpl_output);
         vm.serializeString(implementation, "stakerNode", stakerNodeImpl_output);
         string memory implementation_output = vm.serializeString(
             implementation,
@@ -698,10 +773,21 @@ contract Deploy is Script, Test {
             tokenRegistryOracleProxyDeployTimestamp * 1000
         );
 
+        // WithdrawalManager proxy
+        string memory withdrawalManager_obj = "withdrawalManager";
+        vm.serializeAddress(withdrawalManager_obj, "address", address(withdrawalManager));
+        vm.serializeUint(withdrawalManager_obj, "block", withdrawalManagerProxyDeployBlock);
+        string memory withdrawalManager_output = vm.serializeUint(
+            withdrawalManager_obj,
+            "timestamp",
+            withdrawalManagerProxyDeployTimestamp * 1000
+        );
+
         // Combine all proxy objects
         vm.serializeString(proxy, "liquidTokenManager", liquidTokenManager_output);
         vm.serializeString(proxy, "stakerNodeCoordinator", stakerNodeCoordinator_output);
-        string memory proxy_output = vm.serializeString(proxy, "tokenRegistryOracle", tokenRegistryOracle_output);
+        vm.serializeString(proxy, "tokenRegistryOracle", tokenRegistryOracle_output);
+        string memory proxy_output = vm.serializeString(proxy, "withdrawalManager", withdrawalManager_output);
 
         // Combine implementation and proxy under contractDeployments
         vm.serializeString(contractDeployments, "implementation", implementation_output);

--- a/script/deploy/local/Deploy.s.sol
+++ b/script/deploy/local/Deploy.s.sol
@@ -23,6 +23,8 @@ import {ILiquidTokenManager} from "../../../src/interfaces/ILiquidTokenManager.s
 import {StakerNode} from "../../../src/core/StakerNode.sol";
 import {StakerNodeCoordinator} from "../../../src/core/StakerNodeCoordinator.sol";
 import {IStakerNodeCoordinator} from "../../../src/interfaces/IStakerNodeCoordinator.sol";
+import {WithdrawalManager} from "../../../src/core/WithdrawalManager.sol";
+import {IWithdrawalManager} from "../../../src/interfaces/IWithdrawalManager.sol";
 
 /// @dev To load env file:
 // source .env
@@ -88,6 +90,7 @@ contract Deploy is Script, Test {
     TokenRegistryOracle tokenRegistryOracleImpl;
     LiquidTokenManager liquidTokenManagerImpl;
     StakerNodeCoordinator stakerNodeCoordinatorImpl;
+    WithdrawalManager withdrawalManagerImpl;
     StakerNode stakerNodeImpl;
 
     // Proxy contracts
@@ -95,6 +98,7 @@ contract Deploy is Script, Test {
     TokenRegistryOracle tokenRegistryOracle;
     LiquidTokenManager liquidTokenManager;
     StakerNodeCoordinator stakerNodeCoordinator;
+    WithdrawalManager withdrawalManager;
 
     // Deployment blocks and timestamps
     uint256 public proxyAdminDeployBlock;
@@ -108,6 +112,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerImplDeployTimestamp;
     uint256 public stakerNodeCoordinatorImplDeployBlock;
     uint256 public stakerNodeCoordinatorImplDeployTimestamp;
+    uint256 public withdrawalManagerImplDeployBlock;
+    uint256 public withdrawalManagerImplDeployTimestamp;
     uint256 public stakerNodeImplDeployBlock;
     uint256 public stakerNodeImplDeployTimestamp;
 
@@ -119,6 +125,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerProxyDeployTimestamp;
     uint256 public stakerNodeCoordinatorProxyDeployBlock;
     uint256 public stakerNodeCoordinatorProxyDeployTimestamp;
+    uint256 public withdrawalManagerProxyDeployBlock;
+    uint256 public withdrawalManagerProxyDeployTimestamp;
 
     // Initialization timestamps and blocks
     uint256 public tokenRegistryOracleInitBlock;
@@ -129,6 +137,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerInitTimestamp;
     uint256 public stakerNodeCoordinatorInitBlock;
     uint256 public stakerNodeCoordinatorInitTimestamp;
+    uint256 public withdrawalManagerInitBlock;
+    uint256 public withdrawalManagerInitTimestamp;
     uint256 public oracleSalt;
 
     function run(string memory deployConfigFileName, string memory chain) external {
@@ -155,7 +165,7 @@ contract Deploy is Script, Test {
     }
 
     // Helper function to count array entries
-    function _countTokens(string memory deployConfigData) internal returns (uint256) {
+    function _countTokens(string memory deployConfigData) internal view returns (uint256) {
         uint256 i = 0;
         while (true) {
             string memory prefix = string.concat(".tokens[", vm.toString(i), "].addresses.token");
@@ -261,6 +271,10 @@ contract Deploy is Script, Test {
         stakerNodeCoordinatorImplDeployTimestamp = block.timestamp;
         stakerNodeCoordinatorImpl = new StakerNodeCoordinator();
 
+        withdrawalManagerImplDeployBlock = block.number;
+        withdrawalManagerImplDeployTimestamp = block.timestamp;
+        withdrawalManagerImpl = new WithdrawalManager();
+
         stakerNodeImplDeployBlock = block.number;
         stakerNodeImplDeployTimestamp = block.timestamp;
         stakerNodeImpl = new StakerNode();
@@ -290,6 +304,12 @@ contract Deploy is Script, Test {
         liquidToken = LiquidToken(
             address(new TransparentUpgradeableProxy(address(liquidTokenImpl), address(proxyAdmin), ""))
         );
+
+        withdrawalManagerProxyDeployBlock = block.number;
+        withdrawalManagerProxyDeployTimestamp = block.timestamp;
+        withdrawalManager = WithdrawalManager(
+            address(new TransparentUpgradeableProxy(address(withdrawalManagerImpl), address(proxyAdmin), ""))
+        );
     }
 
     function initializeProxies() internal {
@@ -297,6 +317,7 @@ contract Deploy is Script, Test {
         _initializeLiquidTokenManager();
         _initializeStakerNodeCoordinator();
         _initializeLiquidToken();
+        _initializeWithdrawalManager();
     }
 
     function _initializeTokenRegistryOracle() internal {
@@ -325,6 +346,7 @@ contract Deploy is Script, Test {
                 delegationManager: IDelegationManager(delegationManager),
                 stakerNodeCoordinator: stakerNodeCoordinator,
                 tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle)),
+                withdrawalManager: withdrawalManager,
                 initialOwner: msg.sender, // burner, will transfer to admin
                 strategyController: admin,
                 priceUpdater: address(tokenRegistryOracle)
@@ -338,6 +360,7 @@ contract Deploy is Script, Test {
         stakerNodeCoordinator.initialize(
             IStakerNodeCoordinator.Init({
                 liquidTokenManager: liquidTokenManager,
+                withdrawalManager: withdrawalManager,
                 strategyManager: IStrategyManager(strategyManager),
                 delegationManager: IDelegationManager(delegationManager),
                 maxNodes: STAKER_NODE_COORDINATOR_MAX_NODES,
@@ -360,7 +383,22 @@ contract Deploy is Script, Test {
                 initialOwner: admin,
                 pauser: pauser,
                 liquidTokenManager: ILiquidTokenManager(address(liquidTokenManager)),
-                tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle))
+                tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle)),
+                withdrawalManager: withdrawalManager
+            })
+        );
+    }
+
+    function _initializeWithdrawalManager() internal {
+        withdrawalManagerInitBlock = block.number;
+        withdrawalManagerInitTimestamp = block.timestamp;
+        withdrawalManager.initialize(
+            IWithdrawalManager.Init({
+                initialOwner: admin,
+                delegationManager: IDelegationManager(delegationManager),
+                liquidToken: liquidToken,
+                liquidTokenManager: liquidTokenManager,
+                stakerNodeCoordinator: stakerNodeCoordinator
             })
         );
     }
@@ -454,6 +492,12 @@ contract Deploy is Script, Test {
             _getImplementationFromProxy(address(tokenRegistryOracle)) == address(tokenRegistryOracleImpl),
             "TokenRegistryOracle proxy implementation mismatch"
         );
+
+        // WithdrawalManager
+        require(
+            _getImplementationFromProxy(address(withdrawalManager)) == address(withdrawalManagerImpl),
+            "WithdrawalManager proxy implementation mismatch"
+        );
     }
 
     function _verifyContractConnections() internal view {
@@ -503,6 +547,24 @@ contract Deploy is Script, Test {
         require(
             address(tokenRegistryOracle.liquidTokenManager()) == address(liquidTokenManager),
             "TokenRegistryOracle: wrong liquidTokenManager"
+        );
+
+        // WithdrawalManager
+        require(
+            address(withdrawalManager.delegationManager()) == address(delegationManager),
+            "WithdrawalManager: wrong delegationManager"
+        );
+        require(
+            address(withdrawalManager.liquidToken()) == address(liquidToken),
+            "WithdrawalManager: wrong liquidToken"
+        );
+        require(
+            address(withdrawalManager.liquidTokenManager()) == address(liquidTokenManager),
+            "WithdrawalManager: wrong liquidTokenManager"
+        );
+        require(
+            address(withdrawalManager.stakerNodeCoordinator()) == address(stakerNodeCoordinator),
+            "WithdrawalManager: wrong stakerNodeCoordinator"
         );
 
         // Assets and strategies
@@ -588,11 +650,13 @@ contract Deploy is Script, Test {
             tokenRegistryOracle.hasRole(tokenRegistryOracle.RATE_UPDATER_ROLE(), priceUpdater),
             "Rate Updater role not assigned to priceUpdater in TokenRegistryOracle"
         );
-
         require(
             tokenRegistryOracle.hasRole(tokenRegistryOracle.RATE_UPDATER_ROLE(), address(liquidToken)),
             "Rate Updater role not assigned to LiquidToken in TokenRegistryOracle"
         );
+
+        // WithdrawalManager
+        require(withdrawalManager.hasRole(adminRole, admin), "Admin role not assigned in WithdrawalManager");
     }
 
     function writeDeploymentOutput() internal {
@@ -655,9 +719,20 @@ contract Deploy is Script, Test {
             tokenRegistryOracleImplDeployTimestamp * 1000
         );
 
+        // WithdrawalManager implementation
+        string memory withdrawalManagerImpl_obj = "withdrawalManager";
+        vm.serializeAddress(withdrawalManagerImpl_obj, "address", address(withdrawalManagerImpl));
+        vm.serializeUint(withdrawalManagerImpl_obj, "block", withdrawalManagerImplDeployBlock);
+        string memory withdrawalManagerImpl_output = vm.serializeUint(
+            withdrawalManagerImpl_obj,
+            "timestamp",
+            withdrawalManagerImplDeployTimestamp * 1000
+        );
+
         // Combine all implementation objects
         vm.serializeString(implementation, "liquidTokenManager", liquidTokenManagerImpl_output);
         vm.serializeString(implementation, "stakerNodeCoordinator", stakerNodeCoordinatorImpl_output);
+        vm.serializeString(implementation, "withdrawalManager", withdrawalManagerImpl_output);
         vm.serializeString(implementation, "stakerNode", stakerNodeImpl_output);
         string memory implementation_output = vm.serializeString(
             implementation,
@@ -698,10 +773,21 @@ contract Deploy is Script, Test {
             tokenRegistryOracleProxyDeployTimestamp * 1000
         );
 
+        // WithdrawalManager proxy
+        string memory withdrawalManager_obj = "withdrawalManager";
+        vm.serializeAddress(withdrawalManager_obj, "address", address(withdrawalManager));
+        vm.serializeUint(withdrawalManager_obj, "block", withdrawalManagerProxyDeployBlock);
+        string memory withdrawalManager_output = vm.serializeUint(
+            withdrawalManager_obj,
+            "timestamp",
+            withdrawalManagerProxyDeployTimestamp * 1000
+        );
+
         // Combine all proxy objects
         vm.serializeString(proxy, "liquidTokenManager", liquidTokenManager_output);
         vm.serializeString(proxy, "stakerNodeCoordinator", stakerNodeCoordinator_output);
-        string memory proxy_output = vm.serializeString(proxy, "tokenRegistryOracle", tokenRegistryOracle_output);
+        vm.serializeString(proxy, "tokenRegistryOracle", tokenRegistryOracle_output);
+        string memory proxy_output = vm.serializeString(proxy, "withdrawalManager", withdrawalManager_output);
 
         // Combine implementation and proxy under contractDeployments
         vm.serializeString(contractDeployments, "implementation", implementation_output);

--- a/script/deploy/mainnet/Deploy.s.sol
+++ b/script/deploy/mainnet/Deploy.s.sol
@@ -23,6 +23,8 @@ import {ILiquidTokenManager} from "../../../src/interfaces/ILiquidTokenManager.s
 import {StakerNode} from "../../../src/core/StakerNode.sol";
 import {StakerNodeCoordinator} from "../../../src/core/StakerNodeCoordinator.sol";
 import {IStakerNodeCoordinator} from "../../../src/interfaces/IStakerNodeCoordinator.sol";
+import {WithdrawalManager} from "../../../src/core/WithdrawalManager.sol";
+import {IWithdrawalManager} from "../../../src/interfaces/IWithdrawalManager.sol";
 
 /// @dev To load env file:
 // source .env
@@ -88,6 +90,7 @@ contract Deploy is Script, Test {
     TokenRegistryOracle tokenRegistryOracleImpl;
     LiquidTokenManager liquidTokenManagerImpl;
     StakerNodeCoordinator stakerNodeCoordinatorImpl;
+    WithdrawalManager withdrawalManagerImpl;
     StakerNode stakerNodeImpl;
 
     // Proxy contracts
@@ -95,6 +98,7 @@ contract Deploy is Script, Test {
     TokenRegistryOracle tokenRegistryOracle;
     LiquidTokenManager liquidTokenManager;
     StakerNodeCoordinator stakerNodeCoordinator;
+    WithdrawalManager withdrawalManager;
 
     // Deployment blocks and timestamps
     uint256 public proxyAdminDeployBlock;
@@ -108,6 +112,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerImplDeployTimestamp;
     uint256 public stakerNodeCoordinatorImplDeployBlock;
     uint256 public stakerNodeCoordinatorImplDeployTimestamp;
+    uint256 public withdrawalManagerImplDeployBlock;
+    uint256 public withdrawalManagerImplDeployTimestamp;
     uint256 public stakerNodeImplDeployBlock;
     uint256 public stakerNodeImplDeployTimestamp;
 
@@ -119,6 +125,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerProxyDeployTimestamp;
     uint256 public stakerNodeCoordinatorProxyDeployBlock;
     uint256 public stakerNodeCoordinatorProxyDeployTimestamp;
+    uint256 public withdrawalManagerProxyDeployBlock;
+    uint256 public withdrawalManagerProxyDeployTimestamp;
 
     // Initialization timestamps and blocks
     uint256 public tokenRegistryOracleInitBlock;
@@ -129,6 +137,8 @@ contract Deploy is Script, Test {
     uint256 public liquidTokenManagerInitTimestamp;
     uint256 public stakerNodeCoordinatorInitBlock;
     uint256 public stakerNodeCoordinatorInitTimestamp;
+    uint256 public withdrawalManagerInitBlock;
+    uint256 public withdrawalManagerInitTimestamp;
     uint256 public oracleSalt;
 
     function run(string memory deployConfigFileName) external {
@@ -155,7 +165,7 @@ contract Deploy is Script, Test {
     }
 
     // Helper function to count array entries
-    function _countTokens(string memory deployConfigData) internal returns (uint256) {
+    function _countTokens(string memory deployConfigData) internal view returns (uint256) {
         uint256 i = 0;
         while (true) {
             string memory prefix = string.concat(".tokens[", vm.toString(i), "].addresses.token");
@@ -261,6 +271,10 @@ contract Deploy is Script, Test {
         stakerNodeCoordinatorImplDeployTimestamp = block.timestamp;
         stakerNodeCoordinatorImpl = new StakerNodeCoordinator();
 
+        withdrawalManagerImplDeployBlock = block.number;
+        withdrawalManagerImplDeployTimestamp = block.timestamp;
+        withdrawalManagerImpl = new WithdrawalManager();
+
         stakerNodeImplDeployBlock = block.number;
         stakerNodeImplDeployTimestamp = block.timestamp;
         stakerNodeImpl = new StakerNode();
@@ -290,6 +304,12 @@ contract Deploy is Script, Test {
         liquidToken = LiquidToken(
             address(new TransparentUpgradeableProxy(address(liquidTokenImpl), address(proxyAdmin), ""))
         );
+
+        withdrawalManagerProxyDeployBlock = block.number;
+        withdrawalManagerProxyDeployTimestamp = block.timestamp;
+        withdrawalManager = WithdrawalManager(
+            address(new TransparentUpgradeableProxy(address(withdrawalManagerImpl), address(proxyAdmin), ""))
+        );
     }
 
     function initializeProxies() internal {
@@ -297,6 +317,7 @@ contract Deploy is Script, Test {
         _initializeLiquidTokenManager();
         _initializeStakerNodeCoordinator();
         _initializeLiquidToken();
+        _initializeWithdrawalManager();
     }
 
     function _initializeTokenRegistryOracle() internal {
@@ -325,6 +346,7 @@ contract Deploy is Script, Test {
                 delegationManager: IDelegationManager(delegationManager),
                 stakerNodeCoordinator: stakerNodeCoordinator,
                 tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle)),
+                withdrawalManager: withdrawalManager,
                 initialOwner: msg.sender, // burner, will transfer to admin
                 strategyController: admin,
                 priceUpdater: address(tokenRegistryOracle)
@@ -338,6 +360,7 @@ contract Deploy is Script, Test {
         stakerNodeCoordinator.initialize(
             IStakerNodeCoordinator.Init({
                 liquidTokenManager: liquidTokenManager,
+                withdrawalManager: withdrawalManager,
                 strategyManager: IStrategyManager(strategyManager),
                 delegationManager: IDelegationManager(delegationManager),
                 maxNodes: STAKER_NODE_COORDINATOR_MAX_NODES,
@@ -360,7 +383,22 @@ contract Deploy is Script, Test {
                 initialOwner: admin,
                 pauser: pauser,
                 liquidTokenManager: ILiquidTokenManager(address(liquidTokenManager)),
-                tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle))
+                tokenRegistryOracle: ITokenRegistryOracle(address(tokenRegistryOracle)),
+                withdrawalManager: withdrawalManager
+            })
+        );
+    }
+
+    function _initializeWithdrawalManager() internal {
+        withdrawalManagerInitBlock = block.number;
+        withdrawalManagerInitTimestamp = block.timestamp;
+        withdrawalManager.initialize(
+            IWithdrawalManager.Init({
+                initialOwner: admin,
+                delegationManager: IDelegationManager(delegationManager),
+                liquidToken: liquidToken,
+                liquidTokenManager: liquidTokenManager,
+                stakerNodeCoordinator: stakerNodeCoordinator
             })
         );
     }
@@ -454,6 +492,12 @@ contract Deploy is Script, Test {
             _getImplementationFromProxy(address(tokenRegistryOracle)) == address(tokenRegistryOracleImpl),
             "TokenRegistryOracle proxy implementation mismatch"
         );
+
+        // WithdrawalManager
+        require(
+            _getImplementationFromProxy(address(withdrawalManager)) == address(withdrawalManagerImpl),
+            "WithdrawalManager proxy implementation mismatch"
+        );
     }
 
     function _verifyContractConnections() internal view {
@@ -503,6 +547,24 @@ contract Deploy is Script, Test {
         require(
             address(tokenRegistryOracle.liquidTokenManager()) == address(liquidTokenManager),
             "TokenRegistryOracle: wrong liquidTokenManager"
+        );
+
+        // WithdrawalManager
+        require(
+            address(withdrawalManager.delegationManager()) == address(delegationManager),
+            "WithdrawalManager: wrong delegationManager"
+        );
+        require(
+            address(withdrawalManager.liquidToken()) == address(liquidToken),
+            "WithdrawalManager: wrong liquidToken"
+        );
+        require(
+            address(withdrawalManager.liquidTokenManager()) == address(liquidTokenManager),
+            "WithdrawalManager: wrong liquidTokenManager"
+        );
+        require(
+            address(withdrawalManager.stakerNodeCoordinator()) == address(stakerNodeCoordinator),
+            "WithdrawalManager: wrong stakerNodeCoordinator"
         );
 
         // Assets and strategies
@@ -588,11 +650,13 @@ contract Deploy is Script, Test {
             tokenRegistryOracle.hasRole(tokenRegistryOracle.RATE_UPDATER_ROLE(), priceUpdater),
             "Rate Updater role not assigned to priceUpdater in TokenRegistryOracle"
         );
-
         require(
             tokenRegistryOracle.hasRole(tokenRegistryOracle.RATE_UPDATER_ROLE(), address(liquidToken)),
             "Rate Updater role not assigned to LiquidToken in TokenRegistryOracle"
         );
+
+        // WithdrawalManager
+        require(withdrawalManager.hasRole(adminRole, admin), "Admin role not assigned in WithdrawalManager");
     }
 
     function writeDeploymentOutput() internal {
@@ -655,9 +719,20 @@ contract Deploy is Script, Test {
             tokenRegistryOracleImplDeployTimestamp * 1000
         );
 
+        // WithdrawalManager implementation
+        string memory withdrawalManagerImpl_obj = "withdrawalManager";
+        vm.serializeAddress(withdrawalManagerImpl_obj, "address", address(withdrawalManagerImpl));
+        vm.serializeUint(withdrawalManagerImpl_obj, "block", withdrawalManagerImplDeployBlock);
+        string memory withdrawalManagerImpl_output = vm.serializeUint(
+            withdrawalManagerImpl_obj,
+            "timestamp",
+            withdrawalManagerImplDeployTimestamp * 1000
+        );
+
         // Combine all implementation objects
         vm.serializeString(implementation, "liquidTokenManager", liquidTokenManagerImpl_output);
         vm.serializeString(implementation, "stakerNodeCoordinator", stakerNodeCoordinatorImpl_output);
+        vm.serializeString(implementation, "withdrawalManager", withdrawalManagerImpl_output);
         vm.serializeString(implementation, "stakerNode", stakerNodeImpl_output);
         string memory implementation_output = vm.serializeString(
             implementation,
@@ -698,10 +773,21 @@ contract Deploy is Script, Test {
             tokenRegistryOracleProxyDeployTimestamp * 1000
         );
 
+        // WithdrawalManager proxy
+        string memory withdrawalManager_obj = "withdrawalManager";
+        vm.serializeAddress(withdrawalManager_obj, "address", address(withdrawalManager));
+        vm.serializeUint(withdrawalManager_obj, "block", withdrawalManagerProxyDeployBlock);
+        string memory withdrawalManager_output = vm.serializeUint(
+            withdrawalManager_obj,
+            "timestamp",
+            withdrawalManagerProxyDeployTimestamp * 1000
+        );
+
         // Combine all proxy objects
         vm.serializeString(proxy, "liquidTokenManager", liquidTokenManager_output);
         vm.serializeString(proxy, "stakerNodeCoordinator", stakerNodeCoordinator_output);
-        string memory proxy_output = vm.serializeString(proxy, "tokenRegistryOracle", tokenRegistryOracle_output);
+        vm.serializeString(proxy, "tokenRegistryOracle", tokenRegistryOracle_output);
+        string memory proxy_output = vm.serializeString(proxy, "withdrawalManager", withdrawalManager_output);
 
         // Combine implementation and proxy under contractDeployments
         vm.serializeString(contractDeployments, "implementation", implementation_output);

--- a/src/core/LiquidToken.sol
+++ b/src/core/LiquidToken.sol
@@ -44,11 +44,11 @@ contract LiquidToken is
     /// @notice Mapping of tokens to their corresponding queued balances
     mapping(address => uint256) public queuedAssetBalances;
 
-    /// @notice Mapping of user addresses to their corresponding withdrawal nonces
-    mapping(address => uint256) private _withdrawalNonce;
-
     /// @notice v2 LAT contracts
     IWithdrawalManager public withdrawalManager;
+
+    /// @notice Mapping of user addresses to their corresponding withdrawal nonces
+    mapping(address => uint256) private _withdrawalNonce;
 
     // ------------------------------------------------------------------------------
     // Init functions

--- a/src/core/LiquidTokenManager.sol
+++ b/src/core/LiquidTokenManager.sol
@@ -936,7 +936,7 @@ contract LiquidTokenManager is
         // If receiver is `LiquidToken`, fulfillment is complete since the request has come from rebalancing or node undelegation
         if (receiver == address(liquidToken)) {
             // If there was slashing during the withdrawal queue period, we handle its accounting in the call to `recordRedemptionCompleted()`
-            liquidToken.debitQueuedAssetBalances(receivedTokens, receivedAmounts);
+            liquidToken.debitQueuedAssetBalances(receivedTokens, receivedAmounts, 0);
             // Credit LiquidToken's asset balances
             liquidToken.creditAssetBalances(receivedTokens, receivedAmounts);
         }

--- a/src/core/StakerNode.sol
+++ b/src/core/StakerNode.sol
@@ -103,24 +103,76 @@ contract StakerNode is IStakerNode, Initializable, ReentrancyGuardUpgradeable {
         }
     }
 
-    /// @dev OUT OF SCOPE FOR V1
-    /** 
-    function undelegate()
-        public
-        override
-        onlyRole(STAKER_NODES_DELEGATOR_ROLE)
-    {
-        address currentOperator = operatorDelegation;
-        if (currentOperator == address(0)) revert NodeIsNotDelegated();
+    /// @inheritdoc IStakerNode
+    function withdrawAssets(
+        IStrategy[] calldata strategies,
+        uint256[] calldata shareAmounts
+    ) external override onlyRole(LIQUID_TOKEN_MANAGER_ROLE) returns (bytes32) {
+        if (operatorDelegation == address(0)) revert NodeIsNotDelegated();
+        if (strategies.length != shareAmounts.length) revert LengthMismatch(strategies.length, shareAmounts.length);
+
+        IDelegationManagerTypes.QueuedWithdrawalParams[]
+            memory requestParams = new IDelegationManagerTypes.QueuedWithdrawalParams[](1);
+
+        requestParams[0] = IDelegationManagerTypes.QueuedWithdrawalParams({
+            strategies: strategies,
+            depositShares: shareAmounts,
+            __deprecated_withdrawer: address(this)
+        });
 
         IDelegationManager delegationManager = coordinator.delegationManager();
-        delegationManager.undelegate(address(this));
+        return delegationManager.queueWithdrawals(requestParams)[0];
+    }
 
-        emit UndelegatedFromOperator(currentOperator);
+    /// @inheritdoc IStakerNode
+    function completeWithdrawals(
+        IDelegationManagerTypes.Withdrawal[] calldata withdrawals,
+        IERC20[][] calldata tokens
+    ) external override onlyRole(LIQUID_TOKEN_MANAGER_ROLE) returns (IERC20[] memory) {
+        uint256 arrayLength = withdrawals.length;
+        bool[] memory receiveAsTokensArray = new bool[](arrayLength);
+
+        for (uint256 i = 0; i < arrayLength; i++) {
+            receiveAsTokensArray[i] = true;
+        }
+
+        IDelegationManager delegationManager = coordinator.delegationManager();
+        delegationManager.completeQueuedWithdrawals(withdrawals, tokens, receiveAsTokensArray);
+
+        uint256 totalTokenCount = 0;
+        for (uint256 i = 0; i < tokens.length; i++) {
+            totalTokenCount += tokens[i].length;
+        }
+
+        IERC20[] memory receivedTokens = new IERC20[](totalTokenCount);
+        uint256 uniqueCount = 0;
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            for (uint256 j = 0; j < tokens[i].length; j++) {
+                IERC20 token = tokens[i][j];
+                uint256 balance = token.balanceOf(address(this));
+                if (balance > 0) {
+                    token.safeTransfer(msg.sender, balance);
+                    receivedTokens[uniqueCount++] = token;
+                }
+            }
+        }
+
+        return receivedTokens;
+    }
+
+    /// @inheritdoc IStakerNode
+    function undelegate() external override onlyRole(STAKER_NODES_DELEGATOR_ROLE) returns (bytes32[] memory) {
+        if (operatorDelegation == address(0)) revert NodeIsNotDelegated();
+
+        IDelegationManager delegationManager = coordinator.delegationManager();
+        bytes32[] memory withdrawalRoots = delegationManager.undelegate(address(this));
+
+        emit UndelegatedFromOperator(operatorDelegation);
 
         operatorDelegation = address(0);
+        return withdrawalRoots;
     }
-    */
 
     // ------------------------------------------------------------------------------
     // Getter functions

--- a/src/core/StakerNode.sol
+++ b/src/core/StakerNode.sol
@@ -9,6 +9,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ISignatureUtilsMixinTypes} from "@eigenlayer/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IStrategyManager} from "@eigenlayer/contracts/interfaces/IStrategyManager.sol";
 import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IDelegationManagerTypes} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
 import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
 
 import {IStakerNode} from "../interfaces/IStakerNode.sol";
@@ -32,7 +33,7 @@ contract StakerNode is IStakerNode, Initializable, ReentrancyGuardUpgradeable {
     /// @notice Role identifier for delegation operations
     bytes32 public constant STAKER_NODES_DELEGATOR_ROLE = keccak256("STAKER_NODES_DELEGATOR_ROLE");
 
-    /// @notice LAT contracts
+    /// @notice v1 LAT contracts
     IStakerNodeCoordinator public coordinator;
 
     uint256 public id;

--- a/src/core/StakerNodeCoordinator.sol
+++ b/src/core/StakerNodeCoordinator.sol
@@ -10,6 +10,7 @@ import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationMa
 import {IStakerNodeCoordinator} from "../interfaces/IStakerNodeCoordinator.sol";
 import {IStakerNode} from "../interfaces/IStakerNode.sol";
 import {ILiquidTokenManager} from "../interfaces/ILiquidTokenManager.sol";
+import {IWithdrawalManager} from "../interfaces/IWithdrawalManager.sol";
 
 /**
  * @title StakerNodeCoordinator
@@ -31,11 +32,14 @@ contract StakerNodeCoordinator is IStakerNodeCoordinator, AccessControlUpgradeab
     IStrategyManager public override strategyManager;
     IDelegationManager public override delegationManager;
 
-    /// @notice OZ and LAT contracts
+    /// @notice OZ and v1 LAT contracts
     UpgradeableBeacon public upgradeableBeacon;
     IStakerNode[] private stakerNodes;
 
     uint256 public override maxNodes;
+
+    /// @notice v2 LAT contracts
+    IWithdrawalManager public override withdrawalManager;
 
     // ------------------------------------------------------------------------------
     // Init functions
@@ -57,6 +61,7 @@ contract StakerNodeCoordinator is IStakerNodeCoordinator, AccessControlUpgradeab
             address(init.stakerNodeCreator) == address(0) ||
             address(init.stakerNodesDelegator) == address(0) ||
             address(init.liquidTokenManager) == address(0) ||
+            address(init.withdrawalManager) == address(0) ||
             address(init.strategyManager) == address(0) ||
             address(init.delegationManager) == address(0)
         ) {
@@ -72,6 +77,7 @@ contract StakerNodeCoordinator is IStakerNodeCoordinator, AccessControlUpgradeab
         _grantRole(STAKER_NODES_DELEGATOR_ROLE, init.stakerNodesDelegator);
 
         liquidTokenManager = init.liquidTokenManager;
+        withdrawalManager = init.withdrawalManager;
         strategyManager = init.strategyManager;
         delegationManager = init.delegationManager;
         maxNodes = init.maxNodes;

--- a/src/core/WithdrawalManager.sol
+++ b/src/core/WithdrawalManager.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
+import {IStrategyManager} from "@eigenlayer/contracts/interfaces/IStrategyManager.sol";
+import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IDelegationManagerTypes} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {IWithdrawalManager} from "../interfaces/IWithdrawalManager.sol";
+import {ILiquidToken} from "../interfaces/ILiquidToken.sol";
+import {ILiquidTokenManager} from "../interfaces/ILiquidTokenManager.sol";
+import {IStakerNode} from "../interfaces/IStakerNode.sol";
+import {IStakerNodeCoordinator} from "../interfaces/IStakerNodeCoordinator.sol";
+
+/// @title WithdrawalManager
+/// @notice Manages withdrawals between staker nodes and users
+/// @dev Implements IWithdrawalManager and uses OpenZeppelin's upgradeable contracts
+contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUpgradeable, ReentrancyGuardUpgradeable {
+    using SafeERC20 for IERC20;
+    using Math for uint256;
+
+    // ------------------------------------------------------------------------------
+    // State
+    // ------------------------------------------------------------------------------
+
+    /// @notice EigenLayer contracts
+    IDelegationManager public delegationManager;
+
+    /// @notice LAT contracts
+    ILiquidToken public liquidToken;
+    ILiquidTokenManager public liquidTokenManager;
+    IStakerNodeCoordinator public stakerNodeCoordinator;
+
+    /// @notice User Withdrawals
+    mapping(bytes32 => WithdrawalRequest) public withdrawalRequests;
+    mapping(address => bytes32[]) public userWithdrawalRequests;
+
+    /// @notice Redemptions
+    mapping(bytes32 => ILiquidTokenManager.Redemption) public redemptions;
+
+    /// @notice The delay between user withdrawal request and ability to withdraw from this contract
+    uint256 public withdrawalDelay;
+
+    // ------------------------------------------------------------------------------
+    // Init functions
+    // ------------------------------------------------------------------------------
+
+    /// @dev Disables initializers for the implementation contract
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function initialize(Init memory init) public initializer {
+        __AccessControl_init();
+        __ReentrancyGuard_init();
+
+        if (
+            address(init.initialOwner) == address(0) ||
+            address(init.liquidToken) == address(0) ||
+            address(init.delegationManager) == address(0) ||
+            address(init.liquidTokenManager) == address(0) ||
+            address(init.stakerNodeCoordinator) == address(0)
+        ) {
+            revert ZeroAddress();
+        }
+
+        _grantRole(DEFAULT_ADMIN_ROLE, init.initialOwner);
+
+        delegationManager = init.delegationManager;
+        liquidToken = init.liquidToken;
+        liquidTokenManager = init.liquidTokenManager;
+        stakerNodeCoordinator = init.stakerNodeCoordinator;
+
+        withdrawalDelay = 14 days;
+    }
+
+    // ------------------------------------------------------------------------------
+    // Core functions
+    // ------------------------------------------------------------------------------
+
+    /// @inheritdoc IWithdrawalManager
+    function createWithdrawalRequest(
+        IERC20[] memory assets,
+        uint256[] memory amounts,
+        address user,
+        bytes32 requestId
+    ) external override nonReentrant {
+        if (msg.sender != address(liquidToken)) revert NotLiquidToken(msg.sender);
+
+        WithdrawalRequest memory request = WithdrawalRequest({
+            user: user,
+            assets: assets,
+            requestedAmounts: amounts,
+            withdrawableAmounts: amounts,
+            requestTime: block.timestamp,
+            canFulfill: false
+        });
+
+        withdrawalRequests[requestId] = request;
+        userWithdrawalRequests[user].push(requestId);
+
+        emit WithdrawalInitiated(requestId, user, assets, amounts, block.timestamp);
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function fulfillWithdrawal(bytes32 requestId) external override nonReentrant {
+        WithdrawalRequest storage request = withdrawalRequests[requestId];
+
+        if (request.user == address(0)) revert InvalidWithdrawalRequest();
+        if (request.user != msg.sender) revert UnauthorizedAccess(msg.sender);
+        if (block.timestamp <= request.requestTime + withdrawalDelay) revert WithdrawalDelayNotMet();
+        if (request.canFulfill == false) revert WithdrawalNotReadyToFulfill();
+
+        for (uint256 i = 0; i < request.assets.length; i++) {
+            IERC20 asset = request.assets[i];
+            uint256 amount = request.withdrawableAmounts[i];
+
+            if (asset.balanceOf(address(this)) < amount) {
+                revert InsufficientBalance(asset, amount, asset.balanceOf(address(this)));
+            }
+        }
+
+        address user = request.user;
+        IERC20[] memory assets = request.assets;
+        uint256[] memory amounts = request.withdrawableAmounts;
+
+        delete withdrawalRequests[requestId];
+        bytes32[] storage userRequests = userWithdrawalRequests[user];
+        for (uint256 i = 0; i < userRequests.length; i++) {
+            if (userRequests[i] == requestId) {
+                userRequests[i] = userRequests[userRequests.length - 1];
+                userRequests.pop();
+                break;
+            }
+        }
+
+        // Fulfillment is complete
+        liquidToken.debitQueuedAssetBalances(assets, amounts);
+
+        for (uint256 i = 0; i < assets.length; i++) {
+            assets[i].safeTransfer(msg.sender, amounts[i]);
+        }
+
+        emit WithdrawalFulfilled(requestId, user, assets, amounts, block.timestamp);
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function recordRedemptionCreated(
+        bytes32 redemptionId,
+        ILiquidTokenManager.Redemption calldata redemption
+    ) external override {
+        if (msg.sender != address(liquidTokenManager)) revert NotLiquidTokenManager(msg.sender);
+
+        // Record the redemption
+        redemptions[redemptionId] = redemption;
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function recordRedemptionCompleted(
+        bytes32 redemptionId,
+        IERC20[] calldata receivedAssets,
+        uint256[] calldata receivedAmounts
+    ) external override returns (uint256[] memory) {
+        if (msg.sender != address(liquidTokenManager)) revert NotLiquidTokenManager(msg.sender);
+        if (receivedAmounts.length != receivedAssets.length) revert LengthMismatch();
+
+        ILiquidTokenManager.Redemption memory redemption = redemptions[redemptionId];
+
+        // We have already accounted for slashing up until the point of creating the withdrawal request on EL
+        // Now we compare the received amounts with the original withdrawable amounts (recorded during withdrawal request creation)
+        // to check for any slashing during the withdrawal queue period
+        uint256[] memory slashedFactors = new uint256[](receivedAssets.length);
+        uint256[] memory slashedAmounts = new uint256[](receivedAssets.length);
+
+        for (uint256 i = 0; i < receivedAssets.length; i++) {
+            uint256 originalWithdrawableAmount = 0;
+            bool assetFound = false;
+
+            for (uint256 j = 0; j < redemption.assets.length; j++) {
+                if (address(receivedAssets[i]) == address(redemption.assets[j])) {
+                    originalWithdrawableAmount = redemption.withdrawableAmounts[j];
+                    assetFound = true;
+                    break;
+                }
+            }
+
+            if (receivedAmounts[i] < originalWithdrawableAmount && originalWithdrawableAmount != 0) {
+                slashedFactors[i] = (receivedAmounts[i] * 1e18) / originalWithdrawableAmount;
+
+                slashedAmounts[i] = originalWithdrawableAmount - receivedAmounts[i];
+            } else {
+                slashedFactors[i] = 1e18;
+                slashedAmounts[i] = 0;
+            }
+        }
+
+        // Track the aggregated requested amounts per asset
+        uint256[] memory redemptionRequestedAmounts = new uint256[](receivedAssets.length);
+
+        // If the redemption is for user withdrawal, slash their withdrawable amounts by the slashing factor
+        if (
+            redemption.requestIds.length > 0 && withdrawalRequests[redemption.requestIds[0]].user != address(0) // If one user withdrawal is found, all requests are for user withdrawals
+        ) {
+            for (uint256 i = 0; i < redemption.requestIds.length; i++) {
+                bytes32 requestId = redemption.requestIds[i];
+                WithdrawalRequest storage request = withdrawalRequests[requestId];
+
+                for (uint256 j = 0; j < request.assets.length; j++) {
+                    for (uint256 k = 0; k < receivedAssets.length; k++) {
+                        if (address(request.assets[j]) == address(receivedAssets[k])) {
+                            uint256 originalAmount = request.requestedAmounts[j];
+                            redemptionRequestedAmounts[k] += originalAmount;
+
+                            // Slash the user's withdrawable amount by applying the slashed factor
+                            request.withdrawableAmounts[j] = Math.mulDiv(originalAmount, slashedFactors[k], 1e18);
+
+                            // Emit slashing event if amount was actually slashed
+                            if (slashedFactors[k] < 1e18) {
+                                emit UserSlashed(
+                                    requestId,
+                                    request.user,
+                                    request.assets[j],
+                                    originalAmount,
+                                    request.withdrawableAmounts[j]
+                                );
+                            }
+                            break;
+                        }
+                    }
+                }
+                // Mark withdrawal as ready to fulfill
+                request.canFulfill = true;
+            }
+        }
+
+        // Delete the redemption
+        delete redemptions[redemptionId];
+
+        // Account for withdrawal period slashing in queued withdrawal balances
+        // If the redemption is for rebalancing or undelegation, all internal accounting will now be complete after this
+        // If the redemption is for user withdrawals, the queued balances will still contain the withdrawable amounts
+        liquidToken.debitQueuedAssetBalances(receivedAssets, slashedAmounts);
+
+        return redemptionRequestedAmounts;
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function setWithdrawalDelay(uint256 newDelay) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newDelay < 7 days || newDelay > 30 days) {
+            revert InvalidWithdrawalDelay(newDelay);
+        }
+
+        uint256 oldDelay = withdrawalDelay;
+        withdrawalDelay = newDelay;
+
+        emit WithdrawalDelayUpdated(oldDelay, newDelay);
+    }
+
+    // ------------------------------------------------------------------------------
+    // Getter functions
+    // ------------------------------------------------------------------------------
+
+    /// @inheritdoc IWithdrawalManager
+    function getUserWithdrawalRequests(address user) external view override returns (bytes32[] memory) {
+        return userWithdrawalRequests[user];
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function getWithdrawalRequests(
+        bytes32[] calldata requestIds
+    ) external view override returns (WithdrawalRequest[] memory) {
+        uint256 arrayLength = requestIds.length;
+        WithdrawalRequest[] memory requests = new WithdrawalRequest[](arrayLength);
+
+        for (uint256 i = 0; i < arrayLength; i++) {
+            WithdrawalRequest memory request = withdrawalRequests[requestIds[i]];
+            if (request.user == address(0)) revert WithdrawalRequestNotFound(requestIds[i]);
+            requests[i] = request;
+        }
+
+        return requests;
+    }
+
+    /// @inheritdoc IWithdrawalManager
+    function getRedemption(
+        bytes32 redemptionId
+    ) external view override returns (ILiquidTokenManager.Redemption memory) {
+        ILiquidTokenManager.Redemption memory redemption = redemptions[redemptionId];
+        if (redemption.requestIds.length == 0) revert RedemptionNotFound(redemptionId);
+
+        return redemption;
+    }
+}

--- a/src/interfaces/ILiquidToken.sol
+++ b/src/interfaces/ILiquidToken.sol
@@ -133,7 +133,12 @@ interface ILiquidToken {
     /// @notice Debits queued balances for a given set of assets
     /// @param assets The assets to debit
     /// @param amounts The debit amounts expressed in native token
-    function debitQueuedAssetBalances(IERC20[] calldata assets, uint256[] calldata amounts) external;
+    /// @param sharesToBurn Escrow LAT shares to burn along with this debit (is non-zero only for user withdrawal fulfilment)
+    function debitQueuedAssetBalances(
+        IERC20[] calldata assets,
+        uint256[] calldata amounts,
+        uint256 sharesToBurn
+    ) external;
 
     /// @notice Credits asset balances for a given set of assets
     /// @param assets The assets to credit

--- a/src/interfaces/ILiquidToken.sol
+++ b/src/interfaces/ILiquidToken.sol
@@ -4,6 +4,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {ILiquidTokenManager} from "../interfaces/ILiquidTokenManager.sol";
 import {ITokenRegistryOracle} from "../interfaces/ITokenRegistryOracle.sol";
+import {IWithdrawalManager} from "../interfaces/IWithdrawalManager.sol";
 
 /// @title ILiquidToken Interface
 /// @notice Interface for the LiquidToken contract
@@ -18,20 +19,10 @@ interface ILiquidToken {
         string symbol;
         ILiquidTokenManager liquidTokenManager;
         ITokenRegistryOracle tokenRegistryOracle;
+        IWithdrawalManager withdrawalManager;
         address initialOwner;
         address pauser;
     }
-
-    /// @dev OUT OF SCOPE FOR V1
-    /**
-    struct WithdrawalRequest {
-        address user;
-        IERC20[] assets;
-        uint256[] shareAmounts;
-        uint256 requestTime;
-        bool fulfilled;
-    }
-    */
 
     // ============================================================================
     // EVENTS
@@ -48,28 +39,6 @@ interface ILiquidToken {
         uint256 amount,
         uint256 shares
     );
-
-    /// @dev OUT OF SCOPE FOR V1
-    /**
-    event WithdrawalRequested(
-        bytes32 indexed requestId,
-        address indexed user,
-        IERC20[] assets,
-        uint256[] shareAmounts,
-        uint256 timestamp
-    );
-    */
-
-    /// @dev OUT OF SCOPE FOR V1
-    /**
-    event WithdrawalFulfilled(
-        bytes32 indexed requestId,
-        address indexed user,
-        IERC20[] assets,
-        uint256[] shareAmounts,
-        uint256 timestamp
-    );
-    */
 
     /// @notice Emitted when an asset is transferred
     event AssetTransferred(
@@ -98,13 +67,8 @@ interface ILiquidToken {
     /// @notice Error for unauthorized access by non-LiquidTokenManager
     error NotLiquidTokenManager(address sender);
 
-    /// @dev OUT OF SCOPE FOR V1
-    /**
-    error InvalidWithdrawalRequest();
-    error WithdrawalDelayNotMet();
-    error WithdrawalAlreadyFulfilled();
-    error DuplicateRequestId(bytes32 requestId);
-    */
+    /// @notice Error for unauthorized access
+    error UnauthorizedAccess(address sender);
 
     /// @notice Error for mismatched array lengths
     error ArrayLengthMismatch();
@@ -127,6 +91,12 @@ interface ILiquidToken {
     /// @notice Specific token has invalid price
     error AssetPriceInvalid(address token);
 
+    /// @notice Error for invalid funds recepient
+    error InvalidReceiver(address receiver);
+
+    /// @notice Error for invalid withdrawal request
+    error InvalidWithdrawalRequest();
+
     // ============================================================================
     //  FUNCTIONS
     // ============================================================================
@@ -139,35 +109,42 @@ interface ILiquidToken {
     /// @param assets The ERC20 assets to deposit
     /// @param amounts The amounts of the respective assets to deposit
     /// @param receiver The address to receive the minted shares
-    /// @return sharesArray The array of shares minted for each asset
     function deposit(
         IERC20[] calldata assets,
         uint256[] calldata amounts,
         address receiver
     ) external returns (uint256[] memory);
 
-    /// @dev Out OF SCOPE FOR V1
-    /** 
-    function requestWithdrawal(
-        IERC20[] memory withdrawAssets,
-        uint256[] memory shareAmounts
-    ) external;
-    */
+    /// @notice Allows users to initiate a withdrawal request against their shares
+    /// @param assets The ERC20 assets to withdraw
+    /// @param amounts The amount of tokens to withdraw for each asset
+    function initiateWithdrawal(IERC20[] memory assets, uint256[] memory amounts) external returns (bytes32);
 
-    /// @dev Out OF SCOPE FOR V1
-    /** 
-    function fulfillWithdrawal(bytes32 requestId) external;
-    */
+    /// @notice Previews a withdrawal request and returns whether or not it would be successful
+    /// @param assets The ERC20 assets to withdraw
+    /// @param amounts The amount of tokens to withdraw for each asset
+    function previewWithdrawal(IERC20[] memory assets, uint256[] memory amounts) external view returns (bool);
 
     /// @notice Credits queued balances for a given set of assets
     /// @param assets The assets to credit
     /// @param amounts The credit amounts expressed in native token
     function creditQueuedAssetBalances(IERC20[] calldata assets, uint256[] calldata amounts) external;
 
+    /// @notice Debits queued balances for a given set of assets
+    /// @param assets The assets to debit
+    /// @param amounts The debit amounts expressed in native token
+    function debitQueuedAssetBalances(IERC20[] calldata assets, uint256[] calldata amounts) external;
+
+    /// @notice Credits asset balances for a given set of assets
+    /// @param assets The assets to credit
+    /// @param amounts The credit amounts expressed in native token
+    function creditAssetBalances(IERC20[] calldata assets, uint256[] calldata amounts) external;
+
     /// @notice Allows the LiquidTokenManager to transfer assets from this contract
     /// @param assetsToRetrieve The ERC20 assets to transfer
     /// @param amounts The amounts of each asset to transfer
-    function transferAssets(IERC20[] calldata assetsToRetrieve, uint256[] calldata amounts) external;
+    /// @param receiver The receiver of the funds, either `LiquidTokenManager` or `WithdrawalManager`
+    function transferAssets(IERC20[] calldata assetsToRetrieve, uint256[] calldata amounts, address receiver) external;
 
     /// @notice Calculates the number of shares that correspond to a given amount of an asset
     /// @param asset The ERC20 asset
@@ -184,19 +161,6 @@ interface ILiquidToken {
     /// @notice Returns the total value of assets (staked, queued and unstaked) managed by the contract
     /// @return The total value of assets in the unit of account
     function totalAssets() external view returns (uint256);
-
-    /// @dev Out OF SCOPE FOR V1
-    /**
-    function getUserWithdrawalRequests(address user)
-        external
-        view
-        returns (bytes32[] memory);
-    */
-
-    /// @dev Out OF SCOPE FOR V1
-    /**
-    function getWithdrawalRequest(bytes32 requestId) external view returns (WithdrawalRequest memory);
-    */
 
     /// @notice Returns the unstaked balances for a set of assets
     /// @param assetList The list of assets to get balances for

--- a/src/interfaces/IStakerNode.sol
+++ b/src/interfaces/IStakerNode.sol
@@ -86,10 +86,30 @@ interface IStakerNode {
         IStrategy[] calldata strategies
     ) external;
 
-    /// @dev Out OF SCOPE FOR V1
-    /**
-    function undelegate() external;
-    */
+    /// @notice Creates a withdrawal request of EL for a set of strategies
+    /// @dev EL creates one withdrawal request regardless of the number of strategies
+    /// @param strategies The set of strategies to withdraw from
+    /// @param shareAmounts The amount of shares (unscaled `depositShares`) to withdraw per strategy
+    /// @return The withdrawal root hash from Eigenlayer
+    function withdrawAssets(
+        IStrategy[] calldata strategies,
+        uint256[] calldata shareAmounts
+    ) external returns (bytes32);
+
+    /// @notice Completes a set of withdrawal requests on EL and retrieves funds
+    /// @dev The funds are always withdrawn in tokens and sent to `LiquidTokenManager`, ie the node never keeps unstaked assets
+    /// @param withdrawals The set of EL withdrawals to complete and associated data
+    /// @param tokens The set of tokens to receive funds in
+    /// @return Array of token addresses that were received from the withdrawal
+    function completeWithdrawals(
+        IDelegationManagerTypes.Withdrawal[] calldata withdrawals,
+        IERC20[][] calldata tokens
+    ) external returns (IERC20[] memory);
+
+    /// @notice Undelegates the node from the current operator and withdraws all shares from all strategies
+    /// @dev EL creates one withdrawal request per strategy in the case of undelegation
+    /// @return Array of withdrawal root hashes from Eigenlayer
+    function undelegate() external returns (bytes32[] memory);
 
     /// @notice Returns the address of the current implementation contract
     /// @return The address of the implementation contract

--- a/src/interfaces/IStakerNode.sol
+++ b/src/interfaces/IStakerNode.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.27;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
 import {ISignatureUtilsMixinTypes} from "@eigenlayer/contracts/interfaces/ISignatureUtilsMixin.sol";
+import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IDelegationManagerTypes} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
 
 import {IStakerNodeCoordinator} from "../interfaces/IStakerNodeCoordinator.sol";
 
@@ -57,6 +59,9 @@ interface IStakerNode {
 
     /// @notice Error for undelegating node when not delegated
     error NodeIsNotDelegated();
+
+    /// @notice Error thrown when array lengths don't match in function parameters
+    error LengthMismatch(uint256 length1, uint256 length2);
 
     // ============================================================================
     // FUNCTIONS

--- a/src/interfaces/IStakerNodeCoordinator.sol
+++ b/src/interfaces/IStakerNodeCoordinator.sol
@@ -7,6 +7,7 @@ import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationMa
 
 import {IStakerNode} from "./IStakerNode.sol";
 import {ILiquidTokenManager} from "../interfaces/ILiquidTokenManager.sol";
+import {IWithdrawalManager} from "../interfaces/IWithdrawalManager.sol";
 
 /// @title IStakerNodeCoordinator Interface
 /// @notice Interface for the StakerNodeCoordinator contract

--- a/src/interfaces/IStakerNodeCoordinator.sol
+++ b/src/interfaces/IStakerNodeCoordinator.sol
@@ -18,6 +18,7 @@ interface IStakerNodeCoordinator {
     /// @notice Initialization parameters for StakerNodeCoordinator
     struct Init {
         ILiquidTokenManager liquidTokenManager;
+        IWithdrawalManager withdrawalManager;
         IDelegationManager delegationManager;
         IStrategyManager strategyManager;
         uint256 maxNodes;
@@ -63,9 +64,6 @@ interface IStakerNodeCoordinator {
 
     /// @notice Error for unsupported asset
     error UnsupportedAsset(IERC20 asset);
-
-    /// @notice Error for unauthorized access
-    error Unauthorized();
 
     /// @notice Error for insufficient funds
     error InsufficientFunds();
@@ -148,6 +146,10 @@ interface IStakerNodeCoordinator {
     /// @notice Gets the liquid token manager contract
     /// @return The ILiquidTokenManager interface
     function liquidTokenManager() external view returns (ILiquidTokenManager);
+
+    /// @notice Gets the withdrawal manager contract
+    /// @return The IWithdrawalManager interface
+    function withdrawalManager() external view returns (IWithdrawalManager);
 
     /// @notice Gets the maximum number of nodes allowed
     /// @return The maximum number of nodes

--- a/src/interfaces/IWithdrawalManager.sol
+++ b/src/interfaces/IWithdrawalManager.sol
@@ -185,7 +185,7 @@ interface IWithdrawalManager {
     /// @param receivedAmounts Total amounts per for `receivedAssets` (after any slashing)
     function recordRedemptionCompleted(
         bytes32 redemptionId,
-        IERC20[] calldata assets,
+        IERC20[] calldata receivedAssets,
         uint256[] calldata receivedAmounts
     ) external returns (uint256[] memory);
 

--- a/src/interfaces/IWithdrawalManager.sol
+++ b/src/interfaces/IWithdrawalManager.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IStrategyManager} from "@eigenlayer/contracts/interfaces/IStrategyManager.sol";
+import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IDelegationManagerTypes} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {ILiquidToken} from "./ILiquidToken.sol";
+import {ILiquidTokenManager} from "./ILiquidTokenManager.sol";
+import {IStakerNodeCoordinator} from "./IStakerNodeCoordinator.sol";
+
+/// @title IWithdrawalManager Interface
+/// @notice Interface for managing withdrawals between staker nodes and users
+interface IWithdrawalManager {
+    // ============================================================================
+    // STRUCTS
+    // ============================================================================
+
+    /// @notice Initialization parameters for WithdrawalManager
+    /// @param initialOwner Address that will be granted DEFAULT_ADMIN_ROLE
+    /// @param delegationManager The EigenLayer DelegationManager contract
+    /// @param liquidToken The LiquidToken contract
+    /// @param liquidTokenManager The LiquidTokenManager contract
+    /// @param stakerNodeCoordinator The StakerNodeCoordinator contract
+    struct Init {
+        address initialOwner;
+        IDelegationManager delegationManager;
+        ILiquidToken liquidToken;
+        ILiquidTokenManager liquidTokenManager;
+        IStakerNodeCoordinator stakerNodeCoordinator;
+    }
+
+    /// @notice Represents a user's withdrawal request
+    /// @param user Address of the user requesting withdrawal
+    /// @param assets Array of token addresses being withdrawn
+    /// @param requestedAmounts Array of amounts being withdrawn per asset (in the unit of the asset)
+    /// @param withdrawableAmounts Array of amounts withdrawable per asset after any slashing (in the unit of the asset)
+    /// @param requestTime Timestamp when the withdrawal was requested
+    /// @param canFulfill Whether the withdrawal can be fulfilled by the user (set to true after redemption completion)
+    struct WithdrawalRequest {
+        address user;
+        IERC20[] assets;
+        uint256[] requestedAmounts;
+        uint256[] withdrawableAmounts;
+        uint256 requestTime;
+        bool canFulfill;
+    }
+
+    // ============================================================================
+    // EVENTS
+    // ============================================================================
+
+    /// @notice Emitted when a user initiates a withdrawal request
+    /// @param requestId Unique identifier for the withdrawal request
+    /// @param user Address of the user requesting withdrawal
+    /// @param assets Array of token addresses being withdrawn
+    /// @param amounts Array of amounts being withdrawn per asset
+    /// @param timestamp Block timestamp when the request was made
+    event WithdrawalInitiated(
+        bytes32 indexed requestId,
+        address indexed user,
+        IERC20[] assets,
+        uint256[] amounts,
+        uint256 timestamp
+    );
+
+    /// @notice Emitted when a user's withdrawal request is fulfilled
+    /// @param requestId Unique identifier for the withdrawal request
+    /// @param user Address of the user whose withdrawal was fulfilled
+    /// @param assets Array of token addresses that were withdrawn
+    /// @param amounts Array of token amounts that were withdrawn
+    /// @param timestamp Block timestamp when the fulfillment occurred
+    event WithdrawalFulfilled(
+        bytes32 indexed requestId,
+        address indexed user,
+        IERC20[] assets,
+        uint256[] amounts,
+        uint256 timestamp
+    );
+
+    /// @notice Emitted when a user is slashed and the slashing is applied to the corresponding withdrawable amount on their withdrawal request
+    /// @param requestId Unique identifier for the withdrawal request
+    /// @param user Address of the user whose withdrawal was fulfilled
+    /// @param asset The ERC20 token that was slashed
+    /// @param originalAmount The original withdrawal amount requested by the user on creating the withdrawal request
+    /// @param withdrawableAmount The final withdrawable amount after slashing
+    event UserSlashed(
+        bytes32 indexed requestId,
+        address indexed user,
+        IERC20 indexed asset,
+        uint256 originalAmount,
+        uint256 withdrawableAmount
+    );
+
+    /// @notice Emitted when the withdrawal delay is updated
+    /// @param oldDelay Previous withdrawal delay value
+    /// @param newDelay Newly updated withdrawal delay value
+    event WithdrawalDelayUpdated(uint256 oldDelay, uint256 newDelay);
+
+    // ============================================================================
+    // CUSTOM ERRORS
+    // ============================================================================
+
+    /// @notice Error thrown when a zero address is provided where a non-zero address is required
+    error ZeroAddress();
+
+    /// @notice Error thrown when a function restricted to LiquidToken is called by another address
+    /// @param sender Address that attempted the call
+    error NotLiquidToken(address sender);
+
+    /// @notice Error thrown when a function restricted to LiquidTokenManager is called by another address
+    /// @param sender Address that attempted the call
+    error NotLiquidTokenManager(address sender);
+
+    /// @notice Error thrown when array lengths don't match in function parameters
+    error LengthMismatch();
+
+    /// @notice Error thrown when a withdrawal request is invalid
+    error InvalidWithdrawalRequest();
+
+    /// @notice Error for unauthorized access
+    error UnauthorizedAccess(address sender);
+
+    /// @notice Error thrown when a redemption is invalid
+    error InvalidRedemption();
+
+    /// @notice Error thrown when attempting to fulfill a withdrawal before the delay period
+    error WithdrawalDelayNotMet();
+
+    /// @notice Error thrown when withdrawal cannot be fulfilled yet (redemption not completed)
+    error WithdrawalNotReadyToFulfill();
+
+    /// @notice Error when withdrawal delay value was attempted with an invalid delay value
+    error InvalidWithdrawalDelay(uint256 delay);
+
+    /// @notice Error thrown when a withdrawal request ID doesn't exist
+    /// @param requestId The withdrawal request ID that wasn't found
+    error WithdrawalRequestNotFound(bytes32 requestId);
+
+    /// @notice Error thrown when a redemption ID doesn't exist
+    /// @param redemptionId The redemption ID that wasn't found
+    error RedemptionNotFound(bytes32 redemptionId);
+
+    /// @notice Error thrown when contract has insufficient balance for an operation
+    /// @param asset The token address
+    /// @param required The amount required
+    /// @param available The amount available
+    error InsufficientBalance(IERC20 asset, uint256 required, uint256 available);
+
+    // ============================================================================
+    // FUNCTIONS
+    // ============================================================================
+
+    /// @notice Initializes the contract
+    /// @param init Initialization parameters
+    function initialize(Init memory init) external;
+
+    /// @notice Creates a withdrawal request for a user when they initate one via `LiquidToken`
+    /// @param assets The final assets the the user wants to end up with
+    /// @param amounts The withdrawal amounts per asset
+    /// @param user The requesting user's address
+    /// @param requestId The unique identifier of the withdrawal request
+    function createWithdrawalRequest(
+        IERC20[] memory assets,
+        uint256[] memory amounts,
+        address user,
+        bytes32 requestId
+    ) external;
+
+    /// @notice Allows users to fulfill a withdrawal request after the delay period and receive all corresponding funds
+    /// @param requestId The unique identifier of the withdrawal request
+    function fulfillWithdrawal(bytes32 requestId) external;
+
+    /// @notice Called by `LiquidTokenManger` when a new redemption is created
+    /// @param redemptionId The unique identifier of the redemption
+    /// @param redemption The details of the redemption
+    function recordRedemptionCreated(bytes32 redemptionId, ILiquidTokenManager.Redemption calldata redemption) external;
+
+    /// @notice Called by `LiquidTokenManger` when a redemption is completed
+    /// @dev If there was any slashing during the withdrawal queue period, its accounting is handled here
+    /// @param redemptionId The ID of the redemption
+    /// @param receivedAssets The set of assets that received from all EL withdrawals
+    /// @param receivedAmounts Total amounts per for `receivedAssets` (after any slashing)
+    function recordRedemptionCompleted(
+        bytes32 redemptionId,
+        IERC20[] calldata assets,
+        uint256[] calldata receivedAmounts
+    ) external returns (uint256[] memory);
+
+    /// @notice Updates the withdrawal delay period
+    /// @param newDelay The new withdrawal delay in seconds
+    function setWithdrawalDelay(uint256 newDelay) external;
+
+    /// @notice Returns all withdrawal request IDs for a given user
+    /// @param user The address of the user
+    function getUserWithdrawalRequests(address user) external view returns (bytes32[] memory);
+
+    /// @notice Returns all withdrawal request details for a set of request IDs
+    /// @param requestIds The IDs of the withdrawal requests
+    function getWithdrawalRequests(bytes32[] calldata requestIds) external view returns (WithdrawalRequest[] memory);
+
+    /// @notice Returns all redemption details for a given redemption ID
+    /// @param redemptionId The ID of the redemption
+    function getRedemption(bytes32 redemptionId) external view returns (ILiquidTokenManager.Redemption memory);
+}

--- a/src/interfaces/IWithdrawalManager.sol
+++ b/src/interfaces/IWithdrawalManager.sol
@@ -37,6 +37,7 @@ interface IWithdrawalManager {
     /// @param assets Array of token addresses being withdrawn
     /// @param requestedAmounts Array of amounts being withdrawn per asset (in the unit of the asset)
     /// @param withdrawableAmounts Array of amounts withdrawable per asset after any slashing (in the unit of the asset)
+    /// @param sharesDeposited The LAT shares deposited by the user, to be burned on withdrawal fulfilment
     /// @param requestTime Timestamp when the withdrawal was requested
     /// @param canFulfill Whether the withdrawal can be fulfilled by the user (set to true after redemption completion)
     struct WithdrawalRequest {
@@ -44,6 +45,7 @@ interface IWithdrawalManager {
         IERC20[] assets;
         uint256[] requestedAmounts;
         uint256[] withdrawableAmounts;
+        uint256 sharesDeposited;
         uint256 requestTime;
         bool canFulfill;
     }
@@ -57,12 +59,14 @@ interface IWithdrawalManager {
     /// @param user Address of the user requesting withdrawal
     /// @param assets Array of token addresses being withdrawn
     /// @param amounts Array of amounts being withdrawn per asset
+    /// @param sharesDeposited The LAT shares deposited by the user, to be burned on withdrawal fulfilment
     /// @param timestamp Block timestamp when the request was made
     event WithdrawalInitiated(
         bytes32 indexed requestId,
         address indexed user,
         IERC20[] assets,
         uint256[] amounts,
+        uint256 sharesDeposited,
         uint256 timestamp
     );
 
@@ -105,6 +109,9 @@ interface IWithdrawalManager {
 
     /// @notice Error thrown when a zero address is provided where a non-zero address is required
     error ZeroAddress();
+
+    /// @notice Error for zero amount
+    error ZeroAmount();
 
     /// @notice Error thrown when a function restricted to LiquidToken is called by another address
     /// @param sender Address that attempted the call
@@ -160,11 +167,13 @@ interface IWithdrawalManager {
     /// @notice Creates a withdrawal request for a user when they initate one via `LiquidToken`
     /// @param assets The final assets the the user wants to end up with
     /// @param amounts The withdrawal amounts per asset
+    /// @param sharesDeposited The LAT shares deposited by the user, to be burned on withdrawal fulfilment
     /// @param user The requesting user's address
     /// @param requestId The unique identifier of the withdrawal request
     function createWithdrawalRequest(
         IERC20[] memory assets,
         uint256[] memory amounts,
+        uint256 sharesDeposited,
         address user,
         bytes32 requestId
     ) external;


### PR DESCRIPTION
## Withdrawing Funds from LAT and EigenLayer
We consider a withdrawal to be a:
i.  **Withdrawal Request** when LAT needs to be exchanged  back to LST 
ii. **EL Withdrawal Request** when funds are withdrawn EigenLayer.

In both cases, we make use of the new `WithdrawalManager` contract.

![image](https://github.com/user-attachments/assets/e09d7053-3f11-4c40-88e4-f762d3f944e1)

We define 2 data structures to handle withdrawals across nodes --

#### `IWithdrawalManager.WithdrawalRequest`
Represents a Withdrawal Request made by a user when redeeming underlying LST against their LAT. The user can express which LSTs they want the funds in regardless of which token they deposited when minting LAT. The contract does a preview of the user's preference to make sure that the system actually holds those tokens.

![image](https://github.com/user-attachments/assets/0ddb21ba-d2c7-4034-847c-8552017dbf05)

```
struct WithdrawalRequest {
    address user;
    IERC20[] assets;
    uint256[] requestedAmounts;
    uint256[] withdrawableAmounts;
    uint256 requestTime;
    bool canFulfill;
}
```

#### `ILiquidTokenManager.Redemption`
Represents a set of EL Withdrawal Requests across nodes and to whom the funds need to be transferred once withdrawn from EL. Every Redemption needs to be "completed" (after a delay) on the `LiquidTokenManager` contract in order for the receiver to receive the funds.

Completing a redemption means to complete ALL underlying EL Withdrawal Requests. A redemption cannot be completed partially.
```
struct Redemption {
    bytes32[] requestIds;
    bytes32[] withdrawalRoots;
    IERC20[] assets;
    uint256[] withdrawableAmounts;
    address receiver;
}
```

## Scenarios Involving Withdrawals

#### 1. Users want to redeem underlying LST against their LAT:
- Withdrawal Requests are created by users
- Every epoch, rebalancer looks at the pending Withdrawal Requests and creates a settlement plan ie, how much can be fulfilled from idle funds in `LiquidToken` and how much must be brought in from withdrawing node withdrawals
- The rebalancer then calls `settleUserWithdrawals` by passing in all the `requestIds` that it wants to settle and the settlement plan
- Funds from `LiquidToken` are sent to `WithdrawalManager` and one redemption is created for the remaining funds coming from nodes, with the receiver set as `WithdrawalManager`

Note 1: One EL Withdrawal Request per node is created
Note 2: Rebalancer must index the `RedemptionCreatedForUserWithdrawals` event and keep track of the ordered arrays `nodeIds[]` & `withdrawalRoots[]` required for redemption completion

#### 2. Rebalancer wants to partially withdraw from node(s) to rebalance, causing EL Withdrawal of some staked funds:
- Rebalancer calls the `withdrawFromNodes` fn with the set of nodes and withdrawal plans per node
- One redemption is created with the receiver set as `LiquidToken`

Note 1: One EL Withdrawal Request per node is created
Note 2: Rebalancer must index the `RedemptionCreatedForRebalancing` event and keep track of the ordered arrays `nodeIds[]` & `withdrawalRoots[]` required for redemption completion

#### 3. Rebalancer want to undelegate a node, causing EL Withdrawals of all staked funds:
- Rebalancer calls the `undelegateNodes` fn with the set of nodes to undelegate; all funds to will be removed from EL
- One redemption is created **per node** with the receiver set as `LiquidToken`

Note 1: One EL Withdrawal Request per strategy is created per node. Hence one redemption is created per node.
Note 2: Rebalancer must index the `RedemptionCreatedForNodeUndelegation` event which would be emitted **for each node** and keep track of `nodeId` & `withdrawalRoots[]` required for redemption completion

![image](https://github.com/user-attachments/assets/9486bea3-27be-48f1-bbb5-8023ecf0c7d3)

## Fulfilling Withdrawals
A withdrawal is considered fulfilled once the underlying redemption(s) are completed by the rebalancer calling the `completeRedemption` fn on `LiquidTokenManager` after the EL delay period.  Once done, all funds are transferred to the final `receiver` and share accounting is cleared.

In the case of user withdrawals, there is the additional step of the the user calling the `fulfillWithdrawal` fn on `WithdrawalManager` to retrieve funds to their own wallet.

![image](https://github.com/user-attachments/assets/9ca56847-fd29-418e-8f9b-47f3ad2717d8)

## Additional Notes
#### Share accounting:
- The `totalAssets` function is responsible for calculating all assets held by the LAT system. It does so by adding up `assetBalances[asset]`, `queuedAssetBalances[asset]` and all staked funds from all nodes which it discovers by calling `userUnderlyingView` on EL
- The main consideration with designing withdrawal flow is that when we create an EL Withdrawal Request, the shares are removed from EL accounting and `userUnderlyingView` does not return balances for these queued funds
- To prevent share inflation when LAT price is calculated, we account for these balances per asset by crediting `queuedAssetBalances` every time we create an EL Withdrawal
- On completion of a redemption, we have 2 scenarios:
    - if the redemption is from user withdrawals, fulfillment is only complete after the user withdraws the funds since have taken their tokens in escrow. Hence we debit `queuedAssetBalances` and burn the escrow shares in the `WithdrawalManager.fulfillWithdrawal` fn called by the user
    - else, fulfillment is complete right away after funds are transferred to `LiquidToken`. Hence, we debit `queuedAssetBalances` and credit `assetBalances`. No shares to be burnt as no funds have left the system