### PR TITLE
Feat: Use shares based accounting for withdrawals

### DIFF
--- a/src/core/LiquidToken.sol
+++ b/src/core/LiquidToken.sol
@@ -13,6 +13,7 @@ import {ILiquidToken} from "../interfaces/ILiquidToken.sol";
 import {ILiquidTokenManager} from "../interfaces/ILiquidTokenManager.sol";
 import {ITokenRegistryOracle} from "../interfaces/ITokenRegistryOracle.sol";
 import {IWithdrawalManager} from "../interfaces/IWithdrawalManager.sol";
+import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
 
 /**
  * @title LiquidToken
@@ -41,8 +42,8 @@ contract LiquidToken is
     /// @notice Mapping of assets to their corresponding unstaked balances (held in this contract)
     mapping(address => uint256) public assetBalances;
 
-    /// @notice Mapping of tokens to their corresponding queued balances
-    mapping(address => uint256) public queuedAssetBalances;
+    /// @notice Mapping of tokens to their corresponding queued withdrawable shares (post-slashing)
+    mapping(address => uint256) public queuedAssetElShares;
 
     /// @notice v2 LAT contracts
     IWithdrawalManager public withdrawalManager;
@@ -210,38 +211,38 @@ contract LiquidToken is
     }
 
     /// @inheritdoc ILiquidToken
-    function creditQueuedAssetBalances(IERC20[] calldata assets, uint256[] calldata amounts) external whenNotPaused {
+    function creditQueuedAssetElShares(IERC20[] calldata assets, uint256[] calldata shares) external whenNotPaused {
         if (msg.sender != address(liquidTokenManager) && msg.sender != address(withdrawalManager))
             revert UnauthorizedAccess(msg.sender);
 
-        if (assets.length != amounts.length) revert ArrayLengthMismatch();
+        if (assets.length != shares.length) revert ArrayLengthMismatch();
 
         for (uint256 i = 0; i < assets.length; i++) {
-            queuedAssetBalances[address(assets[i])] += amounts[i];
+            queuedAssetElShares[address(assets[i])] += shares[i];
         }
     }
 
     /// @inheritdoc ILiquidToken
-    function debitQueuedAssetBalances(
+    function debitQueuedAssetElShares(
         IERC20[] calldata assets,
-        uint256[] calldata amounts,
-        uint256 sharesToBurn
+        uint256[] calldata shares,
+        uint256 latSharesToBurn
     ) external whenNotPaused {
         if (msg.sender != address(liquidTokenManager) && msg.sender != address(withdrawalManager))
             revert UnauthorizedAccess(msg.sender);
 
-        if (assets.length != amounts.length) revert ArrayLengthMismatch();
+        if (assets.length != shares.length) revert ArrayLengthMismatch();
 
-        if (sharesToBurn > 0 && balanceOf(address(this)) < sharesToBurn) {
-            revert InsufficientBalance(IERC20(address(this)), sharesToBurn, balanceOf(address(this)));
+        if (latSharesToBurn > 0 && balanceOf(address(this)) < latSharesToBurn) {
+            revert InsufficientBalance(IERC20(address(this)), latSharesToBurn, balanceOf(address(this)));
         }
 
         for (uint256 i = 0; i < assets.length; i++) {
-            queuedAssetBalances[address(assets[i])] -= amounts[i];
+            queuedAssetElShares[address(assets[i])] -= shares[i];
         }
 
-        if (sharesToBurn > 0) {
-            _burn(address(this), sharesToBurn);
+        if (latSharesToBurn > 0) {
+            _burn(address(this), latSharesToBurn);
         }
     }
 
@@ -283,6 +284,7 @@ contract LiquidToken is
             asset.safeTransfer(receiver, amount);
 
             if (assetBalances[address(asset)] > asset.balanceOf(address(this)))
+                // Note: allow for 10bps tolerance and reset the assetBalances amount
                 revert AssetBalanceOutOfSync(
                     assetsToRetrieve[i],
                     assetBalances[address(asset)],
@@ -325,7 +327,7 @@ contract LiquidToken is
             );
 
             // Staked withdrawable asset balances
-            total += liquidTokenManager.getWithdrawableAssetBalance(supportedTokens[i]);
+            total += liquidTokenManager.getWithdrawableAssetBalance(supportedTokens[i], false);
         }
 
         return total;
@@ -386,7 +388,10 @@ contract LiquidToken is
 
     /// @dev Called by `balanceQueuedAssets` and `totalAssets`
     function _balanceQueuedAsset(IERC20 asset) internal view returns (uint256) {
-        return queuedAssetBalances[address(asset)];
+        uint256 shares = queuedAssetElShares[address(asset)];
+        if (shares == 0) return 0;
+
+        return liquidTokenManager.assetSharesToUnderlying(asset, shares);
     }
 
     /// @dev Called by `initiateWithdrawal` and `previewWithdrawal`
@@ -395,7 +400,7 @@ contract LiquidToken is
         for (uint256 i = 0; i < assets.length; i++) {
             IERC20 asset = assets[i];
             if (
-                (assetBalances[address(asset)] + liquidTokenManager.getDepositAssetBalance(asset)) < amounts[i] // Preview with pre-slashing balances
+                (assetBalances[address(asset)] + liquidTokenManager.getDepositAssetBalance(asset, false)) < amounts[i] // Preview with pre-slashing balances
             ) {
                 isPossible = false;
                 break;

--- a/src/core/LiquidTokenManager.sol
+++ b/src/core/LiquidTokenManager.sol
@@ -217,7 +217,7 @@ contract LiquidTokenManager is
 
         unchecked {
             for (uint256 i = 0; i < len; i++) {
-                uint256 stakedWithdrawableBalance = getWithdrawableAssetBalanceNode(token, nodes[i].getId());
+                uint256 stakedWithdrawableBalance = getWithdrawableAssetBalanceNode(token, nodes[i].getId(), true);
                 if (stakedWithdrawableBalance > 0) {
                     revert TokenInUse(token);
                 }
@@ -573,7 +573,7 @@ contract LiquidTokenManager is
         );
 
         // Find withdrawable shares
-        (uint256[] memory redemptionWithdrawableShares, ) = delegationManager.getWithdrawableShares(
+        (uint256[] memory redemptionElWithdrawableShares, ) = delegationManager.getWithdrawableShares(
             address(node),
             redemptionStrategies
         );
@@ -587,7 +587,6 @@ contract LiquidTokenManager is
             withdrawalRoots.length
         );
         IERC20[] memory redemptionAssets = new IERC20[](withdrawalRoots.length); // We can use a 1D array since every withdrawal corresponds to only 1 asset
-        uint256 uniqueTokenCount = 0;
 
         // The order of strategies in `withdrawalRoots[]` is the same as that of `redemptionStrategies[]`
         for (uint256 i = 0; i < withdrawalRoots.length; i++) {
@@ -615,13 +614,8 @@ contract LiquidTokenManager is
             withdrawals[i] = withdrawal;
         }
 
-        // From withdrawable shares, find the underlying withdrawable asset values
-        uint256[] memory redemptionWithdrawableAmounts = new uint256[](uniqueTokenCount);
-        for (uint256 i = 0; i < uniqueTokenCount; i++) {
-            redemptionWithdrawableAmounts[i] = tokenStrategies[redemptionAssets[i]].sharesToUnderlyingView(
-                redemptionWithdrawableShares[i]
-            );
-        }
+        // Credit queued asset shares with total withdrawable shares
+        liquidToken.creditQueuedAssetElShares(redemptionAssets, redemptionElWithdrawableShares);
 
         bytes32[] memory requestIds = new bytes32[](1);
         requestIds[0] = keccak256(abi.encode(redemptionAssets, redemptionShares, block.timestamp, _redemptionNonce));
@@ -631,7 +625,7 @@ contract LiquidTokenManager is
                 requestIds,
                 withdrawalRoots,
                 redemptionAssets,
-                redemptionWithdrawableAmounts,
+                redemptionElWithdrawableShares,
                 address(liquidToken)
             ),
             requestIds[0],
@@ -646,21 +640,21 @@ contract LiquidTokenManager is
     function withdrawNodeAssets(
         uint256[] calldata nodeIds,
         IERC20[][] calldata assets,
-        uint256[][] calldata amounts
+        uint256[][] calldata elDepositShares
     ) external override nonReentrant onlyRole(STRATEGY_CONTROLLER_ROLE) {
         uint256 arrayLength = nodeIds.length;
 
         if (assets.length != arrayLength) revert LengthMismatch(assets.length, arrayLength);
-        if (amounts.length != arrayLength) revert LengthMismatch(amounts.length, arrayLength);
+        if (elDepositShares.length != arrayLength) revert LengthMismatch(elDepositShares.length, arrayLength);
 
-        _createRedemptionRebalancing(nodeIds, assets, amounts);
+        _createRedemptionRebalancing(nodeIds, assets, elDepositShares);
     }
 
     /// @dev Called by `withdrawNodeAssets`
     function _createRedemptionRebalancing(
         uint256[] calldata nodeIds,
         IERC20[][] calldata nodeAssets,
-        uint256[][] calldata nodeAmounts
+        uint256[][] calldata nodeElDepositShares
     ) internal {
         uint256 elActions = nodeIds.length;
 
@@ -669,69 +663,68 @@ contract LiquidTokenManager is
         bytes32[] memory requestIds = new bytes32[](elActions);
 
         IERC20[] memory redemptionAssets = new IERC20[](supportedTokens.length);
-        uint256[] memory redemptionWithdrawableAmounts = new uint256[](supportedTokens.length);
+        uint256[] memory redemptionElWithdrawableShares = new uint256[](supportedTokens.length);
         uint256 uniqueTokenCount = 0;
 
         for (uint256 i = 0; i < elActions; i++) {
-            // Track unscaled deposit shares for each asset so that EL withdrawal struct can be constructed
-            uint256[] memory redemptionSharesNode = new uint256[](nodeAssets[i].length);
             for (uint256 j = 0; j < nodeAssets[i].length; j++) {
                 IERC20 asset = nodeAssets[i][j];
-                uint256 amount = nodeAmounts[i][j];
+                uint256 proposedDepositShares = nodeElDepositShares[i][j];
 
-                if (amount == 0) {
+                if (proposedDepositShares == 0) {
                     revert ZeroAmount();
                 }
 
-                // Track the actual withdrawable amounts after slashing, for internal accounting
-                uint256 depositAssetBalanceNode = getDepositAssetBalanceNode(asset, nodeIds[i]);
+                uint256 depositShares = getDepositAssetBalanceNode(asset, nodeIds[i], true);
                 // EL deposits for the asset must exist and cannot be less than proposed clawback amount
-                if (depositAssetBalanceNode == 0 || depositAssetBalanceNode < amount) {
-                    revert InsufficientBalance(asset, amount, depositAssetBalanceNode);
+                if (depositShares == 0 || depositShares < proposedDepositShares) {
+                    revert InsufficientBalance(asset, proposedDepositShares, depositShares);
                 }
-                uint256 withdrawableAssetBalanceNode = getWithdrawableAssetBalanceNode(asset, nodeIds[i]);
+
+                uint256 withdrawableShares = getWithdrawableAssetBalanceNode(asset, nodeIds[i], true);
 
                 bool found = false;
                 for (uint256 k = 0; k < uniqueTokenCount; k++) {
                     if (redemptionAssets[k] == asset) {
-                        redemptionWithdrawableAmounts[k] +=
-                            (amount * withdrawableAssetBalanceNode) /
-                            depositAssetBalanceNode; // Factor in any slashing
+                        redemptionElWithdrawableShares[k] +=
+                            (proposedDepositShares * withdrawableShares) /
+                            depositShares; // Factor in any slashing
                         found = true;
                         break;
                     }
                 }
                 if (!found) {
                     redemptionAssets[uniqueTokenCount] = asset;
-                    redemptionWithdrawableAmounts[uniqueTokenCount] =
-                        (amount * withdrawableAssetBalanceNode) /
-                        depositAssetBalanceNode; // Factor in any slashing
+                    redemptionElWithdrawableShares[uniqueTokenCount] =
+                        (proposedDepositShares * withdrawableShares) /
+                        depositShares; // Factor in any slashing
                     uniqueTokenCount++;
                 }
-
-                // Convert amounts to EL shares (unscaled deposit shares)
-                redemptionSharesNode[j] = tokenStrategies[asset].underlyingToSharesView(amount);
             }
 
             // Call for EL withdrawals on staker node
-            (withdrawalRoots[i], withdrawals[i]) = _createELWithdrawal(nodeIds[i], nodeAssets[i], redemptionSharesNode);
+            (withdrawalRoots[i], withdrawals[i]) = _createELWithdrawal(
+                nodeIds[i],
+                nodeAssets[i],
+                nodeElDepositShares[i]
+            );
 
             requestIds[i] = keccak256(
-                abi.encode(nodeAssets[i], redemptionSharesNode, block.timestamp, i, _redemptionNonce)
+                abi.encode(nodeAssets[i], nodeElDepositShares[i], block.timestamp, i, _redemptionNonce)
             );
         }
 
-        // Credit queued asset balances with total withdrawable amounts
+        // Credit queued asset shares with total withdrawable shares
         // Here we specifically factor in any slashing of staked funds in order to maintain accurate values for AUM calc
         // If there is any additional slashing after this (during EL withdrawal queue period), we handle it in redemption completion
-        liquidToken.creditQueuedAssetBalances(redemptionAssets, redemptionWithdrawableAmounts);
+        liquidToken.creditQueuedAssetElShares(redemptionAssets, redemptionElWithdrawableShares);
 
         emit RedemptionCreatedForRebalancing(
             _createRedemption(
                 requestIds,
                 withdrawalRoots,
                 redemptionAssets,
-                redemptionWithdrawableAmounts,
+                redemptionElWithdrawableShares,
                 address(liquidToken)
             ),
             requestIds,
@@ -745,40 +738,31 @@ contract LiquidTokenManager is
     /// @inheritdoc ILiquidTokenManager
     function settleUserWithdrawals(
         bytes32[] calldata requestIds,
-        IERC20[] calldata ltAssets,
-        uint256[] calldata ltAmounts,
         uint256[] calldata nodeIds,
         IERC20[][] calldata elAssets,
-        uint256[][] calldata elAmounts
+        uint256[][] calldata elDepositShares
     ) external override nonReentrant onlyRole(STRATEGY_CONTROLLER_ROLE) {
-        uint256 ltActions = ltAssets.length;
         uint256 elActions = nodeIds.length;
 
-        if (ltAmounts.length != ltActions) revert LengthMismatch(ltAmounts.length, ltActions);
         if (elAssets.length != elActions) revert LengthMismatch(elAssets.length, elActions);
-        if (elAmounts.length != elActions) revert LengthMismatch(elAmounts.length, elActions);
+        if (elDepositShares.length != elActions) revert LengthMismatch(elDepositShares.length, elActions);
 
         // Check if all associated withdrawal requests actually get fulfilled from the input amounts
-        (IERC20[] memory redemptionAssets, uint256[] memory redemptionWithdrawableAmounts) = _verifyAllRequestsSettle(
+        (IERC20[] memory redemptionAssets, uint256[] memory redemptionElWithdrawableShares) = _verifyAllRequestsSettle(
             requestIds,
-            ltAssets,
-            ltAmounts,
             nodeIds,
             elAssets,
-            elAmounts
+            elDepositShares
         );
 
-        // Direct unstaked funds from `LiquidToken` to `WithdrawalManager`
-        liquidToken.transferAssets(ltAssets, ltAmounts, address(withdrawalManager));
-
-        // Create a redemption for the rest of the settlement by withdrawing from staker nodes
+        // Create a redemption for the settlement by withdrawing from staker nodes
         _createRedemptionUserWithdrawals(
             requestIds,
             nodeIds,
             elAssets,
-            elAmounts,
+            elDepositShares,
             redemptionAssets,
-            redemptionWithdrawableAmounts
+            redemptionElWithdrawableShares
         );
     }
 
@@ -786,11 +770,9 @@ contract LiquidTokenManager is
     /// @dev Called by `settleUserWithdrawals`
     function _verifyAllRequestsSettle(
         bytes32[] calldata requestIds,
-        IERC20[] calldata ltAssets,
-        uint256[] calldata ltAmounts,
         uint256[] calldata nodeIds,
         IERC20[][] calldata elAssets,
-        uint256[][] calldata elAmounts
+        uint256[][] calldata elDepositShares
     ) internal returns (IERC20[] memory, uint256[] memory) {
         // Get all associated withdrawal requests (reverts for any invalid request id)
         IWithdrawalManager.WithdrawalRequest[] memory withdrawalRequests = withdrawalManager.getWithdrawalRequests(
@@ -799,63 +781,76 @@ contract LiquidTokenManager is
 
         uint256 uniqueTokenCount;
         IERC20[] memory redemptionAssets = new IERC20[](supportedTokens.length);
-        uint256[] memory redemptionAmounts = new uint256[](supportedTokens.length);
+        uint256[] memory redemptionElDepositShares = new uint256[](supportedTokens.length);
 
         // Aggregate cumulative amounts that need to be settled, across all withdrawal requests,
-        (uniqueTokenCount, redemptionAssets, redemptionAmounts) = _processWithdrawalRequests(withdrawalRequests);
-
-        // Use one array to track the proposed amounts to be clawed back from `LiquidToken` and nodes
-        uint256[] memory proposedRedemptionAmounts = new uint256[](uniqueTokenCount);
-        // Use one array to track the actual withdrawable amounts after slashing, for internal accounting
-        uint256[] memory redemptionWithdrawableAmounts = new uint256[](uniqueTokenCount);
-
-        // Aggregate amounts proposed to be clawed from unstaked funds and verify that `LiquidToken` hold enough
-        _processLtAmounts(
-            ltAssets,
-            ltAmounts,
-            redemptionAssets,
-            proposedRedemptionAmounts,
-            redemptionWithdrawableAmounts,
-            uniqueTokenCount
+        (uniqueTokenCount, redemptionAssets, redemptionElDepositShares) = _processWithdrawalRequests(
+            withdrawalRequests
         );
 
-        // Aggregate amounts proposed to be clawed from staked funds and verify that nodes hold enough
-        _processElAmounts(
-            nodeIds,
-            elAssets,
-            elAmounts,
-            redemptionAssets,
-            proposedRedemptionAmounts,
-            redemptionWithdrawableAmounts,
-            uniqueTokenCount
-        );
+        // Track the proposed amounts to be clawed back from nodes
+        uint256[] memory proposedRedemptionElDepositShares = new uint256[](uniqueTokenCount);
 
-        // Verify that the cumulative withdrawal amounts are equal to the proposed clawed amounts, hence settling all requests
-        // We are not concerned with slashing here -- slashing loss will be passed on after withdrawal completion
-        // We allow 10 bps margin of error since `_processElAmounts` has an external price discovery call to EigenLayer contracts
+        // Track the withdrawable amounts after slashing, for internal accounting
+        // This allows correct AUM calc, where queued balances are checked, slashing is included
+        uint256[] memory redemptionElWithdrawableShares = new uint256[](uniqueTokenCount);
+
+        for (uint256 i = 0; i < nodeIds.length; i++) {
+            for (uint256 j = 0; j < elAssets[i].length; j++) {
+                IERC20 token = elAssets[i][j];
+                uint256 proposedDepositShares = elDepositShares[i][j];
+
+                if (proposedDepositShares == 0) {
+                    revert ZeroAmount();
+                }
+
+                uint256 depositShares = getDepositAssetBalanceNode(token, nodeIds[i], true);
+                // EL deposits for the asset must exist and cannot be less than proposed clawback amount
+                if (depositShares == 0 || depositShares < proposedDepositShares) {
+                    revert InsufficientBalance(token, proposedDepositShares, depositShares);
+                }
+
+                uint256 withdrawableShares = getWithdrawableAssetBalanceNode(token, nodeIds[i], true);
+
+                for (uint256 k = 0; k < uniqueTokenCount; k++) {
+                    if (redemptionAssets[k] == token) {
+                        proposedRedemptionElDepositShares[k] += proposedDepositShares;
+                        redemptionElWithdrawableShares[k] +=
+                            (proposedDepositShares * withdrawableShares) /
+                            depositShares; // Factor in any slashing
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Verify that the cumulative deposit shares required are equal to the proposed values, hence settling all requests
+        // We are not concerned with slashing here, hence we use the EL `depositShares` -- slashing loss will be passed on after withdrawal completion
+        // We allow 10 bps margin of error for rounding
         for (uint256 i = 0; i < uniqueTokenCount; i++) {
-            uint256 upperMargin = Math.mulDiv(redemptionAmounts[i], 10, 10000, Math.Rounding.Up);
+            uint256 upperMargin = Math.mulDiv(redemptionElDepositShares[i], 10, 10000, Math.Rounding.Up);
+            uint256 lowerMargin = Math.mulDiv(redemptionElDepositShares[i], 10, 10000, Math.Rounding.Down);
 
-            uint256 lowerMargin = Math.mulDiv(redemptionAmounts[i], 10, 10000, Math.Rounding.Down);
+            uint256 maxAllowed = redemptionElDepositShares[i] + upperMargin;
+            uint256 minAllowed = redemptionElDepositShares[i] - lowerMargin;
 
-            uint256 maxAllowed = redemptionAmounts[i] + upperMargin;
-            uint256 minAllowed = redemptionAmounts[i] - lowerMargin;
-
-            if (proposedRedemptionAmounts[i] > maxAllowed || proposedRedemptionAmounts[i] < minAllowed) {
+            if (
+                proposedRedemptionElDepositShares[i] > maxAllowed || proposedRedemptionElDepositShares[i] < minAllowed
+            ) {
                 revert RequestsDoNotSettle(
                     address(redemptionAssets[i]),
-                    proposedRedemptionAmounts[i],
-                    redemptionAmounts[i]
+                    proposedRedemptionElDepositShares[i],
+                    redemptionElDepositShares[i]
                 );
             }
         }
 
-        // Credit queued asset balances with total withdrawable amounts
-        // Here we specifically factor in any slashing of staked funds in order to maintain accurate values for AUM calc
+        // Credit queued asset shares with total withdrawable amounts, post slashing
+        // As noted above, here we specifically factor in any slashing to maintain accurate AUM calc
         // If there is any additional slashing after this (during EL withdrawal queue period), we handle it in redemption completion
-        liquidToken.creditQueuedAssetBalances(redemptionAssets, redemptionWithdrawableAmounts);
+        liquidToken.creditQueuedAssetElShares(redemptionAssets, redemptionElWithdrawableShares);
 
-        return (redemptionAssets, redemptionWithdrawableAmounts);
+        return (redemptionAssets, redemptionElWithdrawableShares);
     }
 
     /// @dev Called by `_verifyAllRequestsSettle`
@@ -864,10 +859,10 @@ contract LiquidTokenManager is
     )
         internal
         view
-        returns (uint256 uniqueTokenCount, IERC20[] memory redemptionAssets, uint256[] memory redemptionAmounts)
+        returns (uint256 uniqueTokenCount, IERC20[] memory redemptionAssets, uint256[] memory redemptionElDepositShares)
     {
         redemptionAssets = new IERC20[](supportedTokens.length);
-        redemptionAmounts = new uint256[](supportedTokens.length);
+        redemptionElDepositShares = new uint256[](supportedTokens.length);
         uniqueTokenCount = 0;
 
         for (uint256 i = 0; i < withdrawalRequests.length; i++) {
@@ -877,84 +872,15 @@ contract LiquidTokenManager is
                 bool found = false;
                 for (uint256 k = 0; k < uniqueTokenCount; k++) {
                     if (redemptionAssets[k] == token) {
-                        redemptionAmounts[k] += request.requestedAmounts[j];
+                        redemptionElDepositShares[k] += request.elWithdrawableShares[j]; // These are deposit shares for now, we will slash them on redemption completion
                         found = true;
                         break;
                     }
                 }
                 if (!found) {
                     redemptionAssets[uniqueTokenCount] = token;
-                    redemptionAmounts[uniqueTokenCount] = request.requestedAmounts[j];
+                    redemptionElDepositShares[uniqueTokenCount] = request.elWithdrawableShares[j]; // These are deposit shares for now, we will slash them on redemption completion
                     uniqueTokenCount++;
-                }
-            }
-        }
-    }
-
-    /// @dev Called by `_verifyAllRequestsSettle`
-    function _processLtAmounts(
-        IERC20[] calldata ltAssets,
-        uint256[] calldata ltAmounts,
-        IERC20[] memory redemptionAssets,
-        uint256[] memory proposedRedemptionAmounts,
-        uint256[] memory redemptionWithdrawableAmounts,
-        uint256 uniqueTokenCount
-    ) internal view {
-        for (uint256 i = 0; i < ltAssets.length; i++) {
-            IERC20 asset = ltAssets[i];
-            uint256 amount = ltAmounts[i];
-            if (asset.balanceOf(address(liquidToken)) < amount) {
-                revert InsufficientBalance(asset, amount, asset.balanceOf(address(liquidToken)));
-            }
-            for (uint256 j = 0; j < uniqueTokenCount; j++) {
-                if (redemptionAssets[j] == asset) {
-                    proposedRedemptionAmounts[j] += amount;
-                    redemptionWithdrawableAmounts[j] += amount; // Slashing doesn't apply to unstaked funds so we can add `amount` directly
-                    break;
-                }
-            }
-        }
-    }
-
-    /// @dev Called by `_verifyAllRequestsSettle`
-    function _processElAmounts(
-        uint256[] calldata nodeIds,
-        IERC20[][] calldata elAssets,
-        uint256[][] calldata elAmounts,
-        IERC20[] memory redemptionAssets,
-        uint256[] memory proposedRedemptionAmounts,
-        uint256[] memory redemptionWithdrawableAmounts,
-        uint256 uniqueTokenCount
-    ) internal view {
-        for (uint256 i = 0; i < nodeIds.length; i++) {
-            if (elAmounts[i].length != elAssets[i].length) {
-                revert LengthMismatch(elAmounts[i].length, elAssets[i].length);
-            }
-
-            for (uint256 j = 0; j < elAssets[i].length; j++) {
-                IERC20 token = elAssets[i][j];
-                uint256 amount = elAmounts[i][j];
-
-                if (amount == 0) {
-                    revert ZeroAmount();
-                }
-
-                // For settlement verification, record total value of deposits (without slashing) to be requested from EL, across all nodes for each asset
-                uint256 depositAssetBalanceNode = getDepositAssetBalanceNode(token, nodeIds[i]);
-                // EL deposits for the asset must exist and cannot be less than proposed clawback amount
-                if (depositAssetBalanceNode == 0 || depositAssetBalanceNode < amount) {
-                    revert InsufficientBalance(token, amount, depositAssetBalanceNode);
-                }
-                // For internal accounting, record total value of withdrawable amounts (after slashing, if any)
-                uint256 withdrawableAssetBalanceNode = getWithdrawableAssetBalanceNode(token, nodeIds[i]);
-                for (uint256 k = 0; k < uniqueTokenCount; k++) {
-                    if (redemptionAssets[k] == token) {
-                        proposedRedemptionAmounts[k] += amount;
-                        redemptionWithdrawableAmounts[k] +=
-                            (amount * withdrawableAssetBalanceNode) /
-                            depositAssetBalanceNode; // Factor in any slashing
-                        break;
-                    }
                 }
             }
         }
@@ -966,24 +892,18 @@ contract LiquidTokenManager is
         bytes32[] calldata requestIds,
         uint256[] calldata nodeIds,
         IERC20[][] calldata elAssets,
-        uint256[][] calldata elAmounts,
+        uint256[][] calldata elDepositShares,
         IERC20[] memory redemptionAssets,
-        uint256[] memory redemptionWithdrawableAmounts
+        uint256[] memory redemptionElWithdrawableShares
     ) internal {
         bytes32[] memory withdrawalRoots = new bytes32[](nodeIds.length);
         IDelegationManagerTypes.Withdrawal[] memory withdrawals = new IDelegationManagerTypes.Withdrawal[](
             nodeIds.length
         );
 
-        // Call for EL withdrawals on staker nodes
-        uint256[][] memory elShares = new uint256[][](nodeIds.length);
+        // Call for EL withdrawals on staker nodes with the unscaled deposit shares
         for (uint256 i = 0; i < nodeIds.length; i++) {
-            // Convert amounts to EL shares (unscaled deposit shares)
-            for (uint256 j = 0; j < elAmounts[i].length; j++) {
-                elShares[i][j] = tokenStrategies[elAssets[i][j]].underlyingToSharesView(elAmounts[i][j]);
-            }
-
-            (withdrawalRoots[i], withdrawals[i]) = _createELWithdrawal(nodeIds[i], elAssets[i], elShares[i]);
+            (withdrawalRoots[i], withdrawals[i]) = _createELWithdrawal(nodeIds[i], elAssets[i], elDepositShares[i]);
         }
 
         emit RedemptionCreatedForUserWithdrawals(
@@ -991,7 +911,7 @@ contract LiquidTokenManager is
                 requestIds,
                 withdrawalRoots,
                 redemptionAssets,
-                redemptionWithdrawableAmounts,
+                redemptionElWithdrawableShares,
                 address(withdrawalManager)
             ),
             requestIds,
@@ -1043,7 +963,7 @@ contract LiquidTokenManager is
         bytes32[] memory requestIds,
         bytes32[] memory withdrawalRoots,
         IERC20[] memory assets,
-        uint256[] memory withdrawableAmounts,
+        uint256[] memory elWithdrawableShares,
         address receiver
     ) private returns (bytes32) {
         bytes32 redemptionId = keccak256(abi.encode(requestIds, withdrawalRoots, block.timestamp, _redemptionNonce));
@@ -1053,7 +973,7 @@ contract LiquidTokenManager is
             requestIds: requestIds,
             withdrawalRoots: withdrawalRoots,
             assets: assets,
-            withdrawableAmounts: withdrawableAmounts,
+            elWithdrawableShares: elWithdrawableShares,
             receiver: receiver
         });
 
@@ -1127,36 +1047,34 @@ contract LiquidTokenManager is
         // Keep track of the actual amounts received
         // This may differ from the original requested amounts in the `Withdrawal` struct due to slashing
         uint256[] memory receivedAmounts = new uint256[](supportedTokens.length);
+        uint256[] memory receivedElShares = new uint256[](supportedTokens.length);
 
         // Transfer all withdrawn assets to `receiver`, either `LiquidToken` or `WithdrawalManager`
         for (uint256 i = 0; i < uniqueTokenCount; i++) {
             IERC20 token = receivedTokens[i];
             uint256 balance = token.balanceOf(address(this));
             receivedAmounts[i] = balance;
+            receivedElShares[i] = tokenStrategies[token].underlyingToSharesView(balance);
 
             if (balance > 0) {
                 token.safeTransfer(receiver, balance);
             }
         }
 
-        // If receiver is `WithdrawalManager`, fulfillment is yet to be done by users, hence there is no update to accounting yet
-        // If receiver is `LiquidToken`, fulfillment is complete since the request has come from rebalancing or node undelegation
-        if (receiver == address(liquidToken)) {
-            // If there was slashing during the withdrawal queue period, we handle its accounting in the call to `recordRedemptionCompleted()`
-            liquidToken.debitQueuedAssetBalances(receivedTokens, receivedAmounts, 0);
-            // Credit LiquidToken's asset balances
-            liquidToken.creditAssetBalances(receivedTokens, receivedAmounts);
-        }
-
-        // Update Withdrawal Manager and retrieve the original requested amounts
-        uint256[] memory requestedAmounts = withdrawalManager.recordRedemptionCompleted(
+        // Update Withdrawal Manager and retrieve the original requested shares
+        uint256[] memory requestedElShares = withdrawalManager.recordRedemptionCompleted(
             // Accounting for any slashing during withdrawal queue period handled here
             redemptionId,
             receivedTokens,
-            receivedAmounts
+            receivedElShares
         );
 
-        emit RedemptionCompleted(redemptionId, receivedTokens, requestedAmounts, receivedAmounts);
+        // If receiver is `LiquidToken`, we follow the debit done in `recordRedemptionCreated` with a corresponding credit to asset balances
+        if (receiver == address(liquidToken)) {
+            liquidToken.creditAssetBalances(receivedTokens, receivedAmounts);
+        }
+
+        emit RedemptionCompleted(redemptionId, receivedTokens, requestedElShares, receivedAmounts);
     }
 
     /// @dev Called by `completeRedemption`
@@ -1295,7 +1213,7 @@ contract LiquidTokenManager is
     }
 
     /// @inheritdoc ILiquidTokenManager
-    function getDepositAssetBalance(IERC20 asset) external view returns (uint256) {
+    function getDepositAssetBalance(IERC20 asset, bool inElShares) external view returns (uint256) {
         IStrategy strategy = tokenStrategies[asset];
         if (address(strategy) == address(0)) {
             revert StrategyNotFound(address(asset));
@@ -1304,14 +1222,14 @@ contract LiquidTokenManager is
         IStakerNode[] memory nodes = stakerNodeCoordinator.getAllNodes();
         uint256 totalBalance = 0;
         for (uint256 i = 0; i < nodes.length; i++) {
-            totalBalance += _getDepositAssetBalanceNode(asset, nodes[i]);
+            totalBalance += _getDepositAssetBalanceNode(asset, nodes[i], inElShares);
         }
 
         return totalBalance;
     }
 
     /// @inheritdoc ILiquidTokenManager
-    function getDepositAssetBalanceNode(IERC20 asset, uint256 nodeId) public view returns (uint256) {
+    function getDepositAssetBalanceNode(IERC20 asset, uint256 nodeId, bool inElShares) public view returns (uint256) {
         IStrategy strategy = tokenStrategies[asset];
         if (address(strategy) == address(0)) {
             revert StrategyNotFound(address(asset));
@@ -1319,34 +1237,24 @@ contract LiquidTokenManager is
 
         IStakerNode node = stakerNodeCoordinator.getNodeById(nodeId);
 
-        return _getDepositAssetBalanceNode(asset, node);
+        return _getDepositAssetBalanceNode(asset, node, inElShares);
     }
 
     /// @dev Called by `getDepositAssetBalance` and `getDepositAssetBalanceNode`
-    function _getDepositAssetBalanceNode(IERC20 asset, IStakerNode node) internal view returns (uint256) {
+    function _getDepositAssetBalanceNode(
+        IERC20 asset,
+        IStakerNode node,
+        bool inElShares
+    ) internal view returns (uint256) {
         IStrategy strategy = tokenStrategies[asset];
         if (address(strategy) == address(0)) {
             revert StrategyNotFound(address(asset));
         }
-        return strategy.userUnderlyingView(address(node)); // Converts EL shares to underlying asset value
-    }
-
-    /// @notice Gets the staked deposits balance (`depositShares`) of all assets for a specific node
-    /// @dev Currently unused
-    function _getAllDepositAssetBalanceNode(IStakerNode node) internal view returns (uint256[] memory) {
-        uint256[] memory balances = new uint256[](supportedTokens.length);
-        for (uint256 i = 0; i < supportedTokens.length; i++) {
-            IStrategy strategy = tokenStrategies[supportedTokens[i]];
-            if (address(strategy) == address(0)) {
-                revert StrategyNotFound(address(supportedTokens[i]));
-            }
-            balances[i] = strategy.userUnderlyingView(address(node)); // Converts EL shares to underlying asset value
-        }
-        return balances;
+        return inElShares ? strategy.shares(address(node)) : strategy.userUnderlyingView(address(node));
     }
 
     /// @inheritdoc ILiquidTokenManager
-    function getWithdrawableAssetBalance(IERC20 asset) external view returns (uint256) {
+    function getWithdrawableAssetBalance(IERC20 asset, bool inElShares) external view returns (uint256) {
         IStrategy strategy = tokenStrategies[asset];
         if (address(strategy) == address(0)) {
             revert StrategyNotFound(address(asset));
@@ -1355,14 +1263,18 @@ contract LiquidTokenManager is
         IStakerNode[] memory nodes = stakerNodeCoordinator.getAllNodes();
         uint256 totalBalance = 0;
         for (uint256 i = 0; i < nodes.length; i++) {
-            totalBalance += _getWithdrawableAssetBalanceNode(asset, nodes[i]);
+            totalBalance += _getWithdrawableAssetBalanceNode(asset, nodes[i], inElShares);
         }
 
         return totalBalance;
     }
 
     /// @inheritdoc ILiquidTokenManager
-    function getWithdrawableAssetBalanceNode(IERC20 asset, uint256 nodeId) public view returns (uint256) {
+    function getWithdrawableAssetBalanceNode(
+        IERC20 asset,
+        uint256 nodeId,
+        bool inElShares
+    ) public view returns (uint256) {
         IStrategy strategy = tokenStrategies[asset];
         if (address(strategy) == address(0)) {
             revert StrategyNotFound(address(asset));
@@ -1370,11 +1282,15 @@ contract LiquidTokenManager is
 
         IStakerNode node = stakerNodeCoordinator.getNodeById(nodeId);
 
-        return _getWithdrawableAssetBalanceNode(asset, node);
+        return _getWithdrawableAssetBalanceNode(asset, node, inElShares);
     }
 
     /// @dev Called by `getWithdrawableAssetBalance` and `getWithdrawableAssetBalanceNode`
-    function _getWithdrawableAssetBalanceNode(IERC20 asset, IStakerNode node) internal view returns (uint256) {
+    function _getWithdrawableAssetBalanceNode(
+        IERC20 asset,
+        IStakerNode node,
+        bool inElShares
+    ) internal view returns (uint256) {
         IStrategy strategy = tokenStrategies[asset];
         if (address(strategy) == address(0)) {
             revert StrategyNotFound(address(asset));
@@ -1389,7 +1305,7 @@ contract LiquidTokenManager is
             return 0;
         }
 
-        return strategy.sharesToUnderlyingView(withdrawableShares[0]); // Converts EL shares to underlying asset value
+        return inElShares ? withdrawableShares[0] : strategy.sharesToUnderlyingView(withdrawableShares[0]);
     }
 
     /// @inheritdoc ILiquidTokenManager
@@ -1417,5 +1333,25 @@ contract LiquidTokenManager is
     function isStrategySupported(IStrategy strategy) external view returns (bool) {
         if (address(strategy) == address(0)) return false;
         return address(strategyTokens[strategy]) != address(0);
+    }
+
+    /// @inheritdoc ILiquidTokenManager
+    function assetSharesToUnderlying(IERC20 asset, uint256 amount) external view returns (uint256) {
+        IStrategy strategy = tokenStrategies[asset];
+        if (address(strategy) == address(0)) {
+            revert StrategyNotFound(address(asset));
+        }
+
+        return strategy.sharesToUnderlyingView(amount);
+    }
+
+    /// @inheritdoc ILiquidTokenManager
+    function assetUnderlyingToShares(IERC20 asset, uint256 amount) external view returns (uint256) {
+        IStrategy strategy = tokenStrategies[asset];
+        if (address(strategy) == address(0)) {
+            revert StrategyNotFound(address(asset));
+        }
+
+        return strategy.underlyingToSharesView(amount);
     }
 }

--- a/src/core/WithdrawalManager.sol
+++ b/src/core/WithdrawalManager.sol
@@ -96,11 +96,17 @@ contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUp
         if (msg.sender != address(liquidToken)) revert NotLiquidToken(msg.sender);
         if (sharesDeposited == 0) revert ZeroAmount();
 
+        uint256[] memory elWithdrawableShares = new uint256[](assets.length);
+
+        for (uint256 i = 0; i < assets.length; i++) {
+            elWithdrawableShares[i] = liquidTokenManager.assetUnderlyingToShares(assets[i], amounts[i]);
+        }
+
         WithdrawalRequest memory request = WithdrawalRequest({
             user: user,
             assets: assets,
             requestedAmounts: amounts,
-            withdrawableAmounts: amounts,
+            elWithdrawableShares: elWithdrawableShares,
             sharesDeposited: sharesDeposited,
             requestTime: block.timestamp,
             canFulfill: false
@@ -109,7 +115,15 @@ contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUp
         withdrawalRequests[requestId] = request;
         userWithdrawalRequests[user].push(requestId);
 
-        emit WithdrawalInitiated(requestId, user, assets, amounts, sharesDeposited, block.timestamp);
+        emit WithdrawalInitiated(
+            requestId,
+            user,
+            assets,
+            amounts,
+            elWithdrawableShares,
+            sharesDeposited,
+            block.timestamp
+        );
     }
 
     /// @inheritdoc IWithdrawalManager
@@ -121,19 +135,20 @@ contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUp
         if (block.timestamp <= request.requestTime + withdrawalDelay) revert WithdrawalDelayNotMet();
         if (request.canFulfill == false) revert WithdrawalNotReadyToFulfill();
 
+        // Build the amounts array from the user's withdrawable shares
+        uint256[] memory amounts = new uint256[](request.assets.length);
         for (uint256 i = 0; i < request.assets.length; i++) {
             IERC20 asset = request.assets[i];
-            uint256 amount = request.withdrawableAmounts[i];
+            amounts[i] = liquidTokenManager.assetSharesToUnderlying(asset, request.elWithdrawableShares[i]);
 
-            if (asset.balanceOf(address(this)) < amount) {
-                revert InsufficientBalance(asset, amount, asset.balanceOf(address(this)));
+            if (asset.balanceOf(address(this)) < amounts[i]) {
+                revert InsufficientBalance(asset, amounts[i], asset.balanceOf(address(this)));
+                // Note: allow for 10bps tolerance and reset the amounts[i]
             }
         }
 
         address user = request.user;
         IERC20[] memory assets = request.assets;
-        uint256[] memory amounts = request.withdrawableAmounts;
-        uint256 sharesDeposited = request.sharesDeposited;
 
         delete withdrawalRequests[requestId];
         bytes32[] storage userRequests = userWithdrawalRequests[user];
@@ -144,9 +159,6 @@ contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUp
                 break;
             }
         }
-
-        // Fulfillment is complete
-        liquidToken.debitQueuedAssetBalances(assets, amounts, sharesDeposited);
 
         for (uint256 i = 0; i < assets.length; i++) {
             assets[i].safeTransfer(msg.sender, amounts[i]);
@@ -170,10 +182,10 @@ contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUp
     function recordRedemptionCompleted(
         bytes32 redemptionId,
         IERC20[] calldata receivedAssets,
-        uint256[] calldata receivedAmounts
+        uint256[] calldata receivedElShares
     ) external override returns (uint256[] memory) {
         if (msg.sender != address(liquidTokenManager)) revert NotLiquidTokenManager(msg.sender);
-        if (receivedAmounts.length != receivedAssets.length) revert LengthMismatch();
+        if (receivedElShares.length != receivedAssets.length) revert LengthMismatch();
 
         ILiquidTokenManager.Redemption memory redemption = redemptions[redemptionId];
 
@@ -181,80 +193,81 @@ contract WithdrawalManager is IWithdrawalManager, Initializable, AccessControlUp
         // Now we compare the received amounts with the original withdrawable amounts (recorded during withdrawal request creation)
         // to check for any slashing during the withdrawal queue period
         uint256[] memory slashedFactors = new uint256[](receivedAssets.length);
-        uint256[] memory slashedAmounts = new uint256[](receivedAssets.length);
 
         for (uint256 i = 0; i < receivedAssets.length; i++) {
-            uint256 originalWithdrawableAmount = 0;
+            uint256 originalElWithdrawableShares = 0;
             bool assetFound = false;
 
             for (uint256 j = 0; j < redemption.assets.length; j++) {
                 if (address(receivedAssets[i]) == address(redemption.assets[j])) {
-                    originalWithdrawableAmount = redemption.withdrawableAmounts[j];
+                    originalElWithdrawableShares = redemption.elWithdrawableShares[j];
                     assetFound = true;
                     break;
                 }
             }
 
-            if (receivedAmounts[i] < originalWithdrawableAmount && originalWithdrawableAmount != 0) {
-                slashedFactors[i] = (receivedAmounts[i] * 1e18) / originalWithdrawableAmount;
-
-                slashedAmounts[i] = originalWithdrawableAmount - receivedAmounts[i];
+            if (receivedElShares[i] < originalElWithdrawableShares && originalElWithdrawableShares != 0) {
+                slashedFactors[i] = (receivedElShares[i] * 1e18) / originalElWithdrawableShares;
             } else {
                 slashedFactors[i] = 1e18;
-                slashedAmounts[i] = 0;
             }
         }
 
         // Track the aggregated requested amounts per asset
-        uint256[] memory redemptionRequestedAmounts = new uint256[](receivedAssets.length);
+        uint256[] memory redemptionRequestedElShares = new uint256[](receivedAssets.length);
+        uint256 latEscrowShares = 0;
 
-        // If the redemption is for user withdrawal, slash their withdrawable amounts by the slashing factor
-        if (
-            redemption.requestIds.length > 0 && withdrawalRequests[redemption.requestIds[0]].user != address(0) // If one user withdrawal is found, all requests are for user withdrawals
-        ) {
-            for (uint256 i = 0; i < redemption.requestIds.length; i++) {
-                bytes32 requestId = redemption.requestIds[i];
-                WithdrawalRequest storage request = withdrawalRequests[requestId];
+        // If one user withdrawal is found, all requests are for user withdrawals
+        bool isUserWithdrawal = redemption.requestIds.length > 0 &&
+            withdrawalRequests[redemption.requestIds[0]].user != address(0);
 
-                for (uint256 j = 0; j < request.assets.length; j++) {
-                    for (uint256 k = 0; k < receivedAssets.length; k++) {
-                        if (address(request.assets[j]) == address(receivedAssets[k])) {
-                            uint256 originalAmount = request.requestedAmounts[j];
-                            redemptionRequestedAmounts[k] += originalAmount;
+        for (uint256 i = 0; i < redemption.requestIds.length; i++) {
+            bytes32 requestId = redemption.requestIds[i];
+            WithdrawalRequest storage request = withdrawalRequests[requestId];
 
-                            // Slash the user's withdrawable amount by applying the slashed factor
-                            request.withdrawableAmounts[j] = Math.mulDiv(originalAmount, slashedFactors[k], 1e18);
+            for (uint256 j = 0; j < request.assets.length; j++) {
+                for (uint256 k = 0; k < receivedAssets.length; k++) {
+                    if (address(request.assets[j]) == address(receivedAssets[k])) {
+                        uint256 originalShares = request.elWithdrawableShares[j];
+                        redemptionRequestedElShares[k] += originalShares;
+                        latEscrowShares += request.sharesDeposited;
 
-                            // Emit slashing event if amount was actually slashed
+                        // For user withdrawals, slash the user's withdrawable shares by applying the slashed factor
+                        if (isUserWithdrawal) {
+                            request.elWithdrawableShares[j] = Math.mulDiv(originalShares, slashedFactors[k], 1e18);
+
                             if (slashedFactors[k] < 1e18) {
                                 emit UserSlashed(
                                     requestId,
                                     request.user,
                                     request.assets[j],
-                                    originalAmount,
-                                    request.withdrawableAmounts[j]
+                                    originalShares,
+                                    request.elWithdrawableShares[j]
                                 );
                             }
                             break;
                         }
                     }
                 }
-                // Mark withdrawal as ready to fulfill
-                request.canFulfill = true;
             }
+
+            // Mark withdrawal as ready to fulfill
+            request.canFulfill = true;
         }
 
         // Delete the redemption
         delete redemptions[redemptionId];
 
-        // Account for withdrawal period slashing in queued withdrawal balances
-        // If the redemption is for rebalancing or undelegation, all internal accounting will now be complete after this
-        // If the redemption is for user withdrawals,
-        //  - the queued balances will still contain the withdrawable amounts
-        //  - the deposited escrow LAT shares are still to be burnt
-        liquidToken.debitQueuedAssetBalances(receivedAssets, slashedAmounts, 0);
+        // Clear the queued shares accounting
+        // If the redemption is for rebalancing or undelegation, a corresponding credit to asset balances will be done in `completeRedemption`
+        // If the redemption is for user withdrawals, we burn the escrow shares deposited by the user
+        if (isUserWithdrawal) {
+            liquidToken.debitQueuedAssetElShares(receivedAssets, redemptionRequestedElShares, latEscrowShares);
+        } else {
+            liquidToken.debitQueuedAssetElShares(receivedAssets, redemptionRequestedElShares, 0);
+        }
 
-        return redemptionRequestedAmounts;
+        return redemptionRequestedElShares;
     }
 
     /// @inheritdoc IWithdrawalManager

--- a/src/interfaces/ILiquidToken.sol
+++ b/src/interfaces/ILiquidToken.sol
@@ -125,19 +125,19 @@ interface ILiquidToken {
     /// @param amounts The amount of tokens to withdraw for each asset
     function previewWithdrawal(IERC20[] memory assets, uint256[] memory amounts) external view returns (bool);
 
-    /// @notice Credits queued balances for a given set of assets
+    /// @notice Credits queued balances for a given set of assets denoted in their corresponding EL shares
     /// @param assets The assets to credit
-    /// @param amounts The credit amounts expressed in native token
-    function creditQueuedAssetBalances(IERC20[] calldata assets, uint256[] calldata amounts) external;
+    /// @param amounts The credit amounts expressed in EL shares
+    function creditQueuedAssetElShares(IERC20[] calldata assets, uint256[] calldata amounts) external;
 
-    /// @notice Debits queued balances for a given set of assets
+    /// @notice Debits queued balances for a given set of assets denoted in their corresponding EL shares
     /// @param assets The assets to debit
-    /// @param amounts The debit amounts expressed in native token
-    /// @param sharesToBurn Escrow LAT shares to burn along with this debit (is non-zero only for user withdrawal fulfilment)
-    function debitQueuedAssetBalances(
+    /// @param amounts The debit amounts expressed in EL shares
+    /// @param latSharesToBurn Escrow LAT shares to burn along with this debit (is non-zero only for user withdrawal fulfilment)
+    function debitQueuedAssetElShares(
         IERC20[] calldata assets,
         uint256[] calldata amounts,
-        uint256 sharesToBurn
+        uint256 latSharesToBurn
     ) external;
 
     /// @notice Credits asset balances for a given set of assets

--- a/src/interfaces/ILiquidTokenManager.sol
+++ b/src/interfaces/ILiquidTokenManager.sol
@@ -75,11 +75,13 @@ interface ILiquidTokenManager {
     /// @param requestIds Array of request IDs associated with this redemption
     /// @param withdrawalRoots Array of withdrawal roots from EigenLayer withdrawals
     /// @param receiver Contract that will receive the withdrawn funds (`LiquidToken` or `WithdrawalManager`)
+    /// @param assets Array of token addresses being withdrawn
+    /// @param elWithdrawableShares Array of EL shares withdrawable per asset (after any slashing)
     struct Redemption {
         bytes32[] requestIds;
         bytes32[] withdrawalRoots;
         IERC20[] assets;
-        uint256[] withdrawableAmounts;
+        uint256[] elWithdrawableShares;
         address receiver;
     }
 
@@ -188,7 +190,7 @@ interface ILiquidTokenManager {
     event RedemptionCompleted(
         bytes32 indexed redemptionId,
         IERC20[] assets,
-        uint256[] requestedAmounts,
+        uint256[] requestedElShares,
         uint256[] receivedAmounts
     );
 
@@ -367,34 +369,28 @@ interface ILiquidTokenManager {
     /// @dev Strategies are always withdrawn into their respective assets, they are never converted
     /// @param nodeIds The ID of the nodes to withdraw from
     /// @param assets The array of assets to withdraw for each node
-    /// @param amounts The amounts for `assets`
+    /// @param elDepositShares The EL deposit shares for `assets` (unscaled, pre-slashing shares)
     function withdrawNodeAssets(
         uint256[] calldata nodeIds,
         IERC20[][] calldata assets,
-        uint256[][] calldata amounts
+        uint256[][] calldata elDepositShares
     ) external;
 
     /// @notice Enables a set of user withdrawal requests to be fulfillable after 14 days by the respective users
-    /// @dev The caller can allocate funds from both, unstaked and staked balances in the proportion it deems fit
-    /// @dev This function accepts a settlement only if it will actually allocate enough funds per token to settle ALL user withdrawal requests
-    /// @dev If any part of the settlement draws from unstaked balances, funds are transferred right away from `LiquidToken` to `WithdrawalManager`
-    /// @dev If any part of the settlement draws from staked balances, a redemption is created on completion of which, funds are transferred to `WithdrawalManager`
+    /// @dev This function only uses staked balances from EigenLayer to ensure fair slashing distribution
+    /// @dev This function accepts a settlement only if it will actually allocate enough EL shares per token to settle ALL user withdrawal requests
+    /// @dev A redemption is created and on completion, funds are transferred to `WithdrawalManager`
     /// @dev Caller should index the `RedemptionCreatedForUserWithdrawals` event to have the required data for redemption completion
-    /// @dev The function is not concerned with actual amounts withdrawn from EL after slashing, if any
-    /// @dev The caller is free to decide how much of slashing loss to pass on to users --  more allocation from unstaked balances => less slashing impact
+    /// @dev All users share the same post-slashing conversion rate, ensuring fair loss distribution
     /// @param requestIds The request IDs of the user withdrawal requests to be fulfilled
-    /// @param ltAssets The assets that will be drawn from `LiquidToken`
-    /// @param ltAmounts The amounts for `ltAssets`
     /// @param nodeIds The node IDs from which funds will be withdrawn
     /// @param elAssets The array of assets to be withdrawn for a given node from EigenLayer
-    /// @param elAmounts The amounts for `elAssets`
+    /// @param elDepositShares The EL deposit shares for `elAssets` (unscaled, pre-slashing shares)
     function settleUserWithdrawals(
         bytes32[] calldata requestIds,
-        IERC20[] calldata ltAssets,
-        uint256[] calldata ltAmounts,
         uint256[] calldata nodeIds,
         IERC20[][] calldata elAssets,
-        uint256[][] calldata elAmounts
+        uint256[][] calldata elDepositShares
     ) external;
 
     /// @notice Completes withdrawals on EigenLayer for a given redemption and transfers funds to the `receiver` of the redemption
@@ -439,28 +435,36 @@ interface ILiquidTokenManager {
     function getStrategyToken(IStrategy strategy) external view returns (IERC20);
 
     /// @notice Gets the staked deposits balance of an asset for all nodes
-    /// @dev This corresponds to the asset value of `depositShares` which does not factor in any slashing
+    /// @dev This corresponds to the value of `depositShares` which does not factor in any slashing
     /// @param asset The asset to check the balance for
+    /// @param inElShares Whether to return EL shares (true) or underlying amount (false)
     /// @return The total staked balance of the asset across all nodes
-    function getDepositAssetBalance(IERC20 asset) external view returns (uint256);
+    function getDepositAssetBalance(IERC20 asset, bool inElShares) external view returns (uint256);
 
     /// @notice Gets the staked deposits balance of an asset for a specific node
-    /// @dev This corresponds to the asset value of `depositShares` which does not factor in any slashing
+    /// @dev This corresponds to the value of `depositShares` which does not factor in any slashing
     /// @param asset The asset to check the balance for
     /// @param nodeId The ID of the node
+    /// @param inElShares Whether to return EL shares (true) or underlying amount (false)
     /// @return The staked balance of the asset for the specific node
-    function getDepositAssetBalanceNode(IERC20 asset, uint256 nodeId) external view returns (uint256);
+    function getDepositAssetBalanceNode(IERC20 asset, uint256 nodeId, bool inElShares) external view returns (uint256);
 
     /// @notice Gets the withdrawable balance of an asset for all nodes
-    /// @dev This corresponds to the asset value of `withdrawableShares` which is `depositShares` minus slashing if any
+    /// @dev This corresponds to the value of `withdrawableShares` which is `depositShares` minus slashing if any
     /// @param asset The asset token address
-    function getWithdrawableAssetBalance(IERC20 asset) external view returns (uint256);
+    /// @param inElShares Whether to return EL shares (true) or underlying amount (false)
+    function getWithdrawableAssetBalance(IERC20 asset, bool inElShares) external view returns (uint256);
 
     /// @notice Gets the withdrawable balance of an asset for a specific node
-    /// @dev This corresponds to the asset value of `withdrawableShares` which is `depositShares` minus slashing if any
+    /// @dev This corresponds to the value of `withdrawableShares` which is `depositShares` minus slashing if any
     /// @param asset The asset token address
     /// @param nodeId The ID of the node
-    function getWithdrawableAssetBalanceNode(IERC20 asset, uint256 nodeId) external view returns (uint256);
+    /// @param inElShares Whether to return EL shares (true) or underlying amount (false)
+    function getWithdrawableAssetBalanceNode(
+        IERC20 asset,
+        uint256 nodeId,
+        bool inElShares
+    ) external view returns (uint256);
 
     /// @notice Checks if a token is supported
     /// @param token Address of the token to check
@@ -483,6 +487,18 @@ interface ILiquidTokenManager {
     /// @param strategy The strategy address
     /// @return True if the strategy is supported
     function isStrategySupported(IStrategy strategy) external view returns (bool);
+
+    /// @notice Convert a given amount EL shares of a token to its underlying value
+    /// @param asset Address of the token
+    /// @param amount Amount of shares
+    /// @return Underlying asset value
+    function assetSharesToUnderlying(IERC20 asset, uint256 amount) external view returns (uint256);
+
+    /// @notice Convert a given amount of a token to EL shares amount
+    /// @param asset Address of the token
+    /// @param amount Amount of token
+    /// @return EL shares amount
+    function assetUnderlyingToShares(IERC20 asset, uint256 amount) external view returns (uint256);
 
     /// @notice Returns the token registry oracle contract
     /// @return The ITokenRegistryOracle interface

--- a/src/interfaces/IWithdrawalManager.sol
+++ b/src/interfaces/IWithdrawalManager.sol
@@ -36,7 +36,7 @@ interface IWithdrawalManager {
     /// @param user Address of the user requesting withdrawal
     /// @param assets Array of token addresses being withdrawn
     /// @param requestedAmounts Array of amounts being withdrawn per asset (in the unit of the asset)
-    /// @param withdrawableAmounts Array of amounts withdrawable per asset after any slashing (in the unit of the asset)
+    /// @param elWithdrawableShares Array of EL shares withdrawable per asset (after any slashing)
     /// @param sharesDeposited The LAT shares deposited by the user, to be burned on withdrawal fulfilment
     /// @param requestTime Timestamp when the withdrawal was requested
     /// @param canFulfill Whether the withdrawal can be fulfilled by the user (set to true after redemption completion)
@@ -44,7 +44,7 @@ interface IWithdrawalManager {
         address user;
         IERC20[] assets;
         uint256[] requestedAmounts;
-        uint256[] withdrawableAmounts;
+        uint256[] elWithdrawableShares;
         uint256 sharesDeposited;
         uint256 requestTime;
         bool canFulfill;
@@ -59,6 +59,7 @@ interface IWithdrawalManager {
     /// @param user Address of the user requesting withdrawal
     /// @param assets Array of token addresses being withdrawn
     /// @param amounts Array of amounts being withdrawn per asset
+    /// @param withdrawableElShares Array of withdrawable EL shares per asset
     /// @param sharesDeposited The LAT shares deposited by the user, to be burned on withdrawal fulfilment
     /// @param timestamp Block timestamp when the request was made
     event WithdrawalInitiated(
@@ -66,6 +67,7 @@ interface IWithdrawalManager {
         address indexed user,
         IERC20[] assets,
         uint256[] amounts,
+        uint256[] withdrawableElShares,
         uint256 sharesDeposited,
         uint256 timestamp
     );
@@ -191,11 +193,11 @@ interface IWithdrawalManager {
     /// @dev If there was any slashing during the withdrawal queue period, its accounting is handled here
     /// @param redemptionId The ID of the redemption
     /// @param receivedAssets The set of assets that received from all EL withdrawals
-    /// @param receivedAmounts Total amounts per for `receivedAssets` (after any slashing)
+    /// @param receivedElShares Total EL shares received per `receivedAssets` (converted from underlying amounts)
     function recordRedemptionCompleted(
         bytes32 redemptionId,
         IERC20[] calldata receivedAssets,
-        uint256[] calldata receivedAmounts
+        uint256[] calldata receivedElShares
     ) external returns (uint256[] memory);
 
     /// @notice Updates the withdrawal delay period


### PR DESCRIPTION
- All queued balances are now denoted in EL shares to prevent accounting imbalances esp for rebasing tokens
- `settleUserWithdrawals` and `withdrawNodeAssets` now take inputs denoted in EL shares
- `settleUserWithdrawals` cannot draw upon unstaked funds for settlement -- this prevents the possibility of slashing loss accumulation over time which gets passed on to longer-term holders
- Escrow shares taken from users on withdrawal creation are now burnt on redemption completion instead of user fulfillment. This is more accurate for LAT pricing since neither the funds nor escrow shares are usable anymore and slashing loss would've unnecessarily persisted on the pricing until the user withdraws their funds